### PR TITLE
[Fix] CI 빌드에 API base URL 주입

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,3 +39,5 @@ jobs:
 
       - name: Build
         run: pnpm build
+        env:
+          NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}


### PR DESCRIPTION
## What is this PR? :mag:
CI 빌드에 NEXT_PUBLIC_API_BASE_URL 환경변수 주입

## Changes :memo:
- Build 단계에 NEXT_PUBLIC_API_BASE_URL 시크릿 주입

## Related Issues :link:
Closes #40 

## Screenshot :camera:

---

### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to properly pass API base URL environment variable to the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->