### PR TITLE
[Feat] 캘린더 페이지 구현

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,16 +1,20 @@
+import CalendarMonth from '@/src/components/features/calendar/CalendarMonth/CalendarMonth';
 import StreakBanner from '@/src/components/features/calendar/StreakBanner/StreackBanner';
+import SummaryCard from '@/src/components/features/calendar/SummaryCard/SummaryCard';
 import PageHeader from '@/src/components/layout/PageHeader/PageHeader';
 import BottomNavBar from '@/src/components/ui/BottomNavBar';
 
 const CalendarPage = () => {
   return (
-    <>
+    <div className="space-y-5 pb-28">
       <PageHeader title="캘린더" />
       <StreakBanner />
+      <CalendarMonth />
+      <SummaryCard />
 
       {/* TODO: 바뀐 디자인 반영 확인 해야 함 */}
       <BottomNavBar />
-    </>
+    </div>
   );
 };
 

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,0 +1,17 @@
+import StreakBanner from '@/src/components/features/calendar/StreakBanner/StreackBanner';
+import PageHeader from '@/src/components/layout/PageHeader/PageHeader';
+import BottomNavBar from '@/src/components/ui/BottomNavBar';
+
+const CalendarPage = () => {
+  return (
+    <>
+      <PageHeader title="캘린더" />
+      <StreakBanner />
+
+      {/* TODO: 바뀐 디자인 반영 확인 해야 함 */}
+      <BottomNavBar />
+    </>
+  );
+};
+
+export default CalendarPage;

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,19 +1,60 @@
+'use client';
+
+import { format } from 'date-fns';
+import { useRouter } from 'next/navigation';
+
 import CalendarMonth from '@/src/components/features/calendar/CalendarMonth/CalendarMonth';
+import { useCalendarState } from '@/src/components/features/calendar/hooks/useCalendarState';
 import StreakBanner from '@/src/components/features/calendar/StreakBanner/StreackBanner';
 import SummaryCard from '@/src/components/features/calendar/SummaryCard/SummaryCard';
+import { useMonthReflectionQuery } from '@/src/components/features/reflection/queries/useMonthReflectionQuery';
+import { useTodayReflectionQuery } from '@/src/components/features/reflection/queries/useTodayReflectionQuery';
+import { useUserDetailQuery } from '@/src/components/features/users/queries/useUserDetailQuery';
 import PageHeader from '@/src/components/layout/PageHeader/PageHeader';
 import BottomNavBar from '@/src/components/ui/BottomNavBar';
+import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
 
 const CalendarPage = () => {
+  const router = useRouter();
+
+  const calendarState = useCalendarState();
+  const formattedMonth = format(calendarState.currentMonth, 'yyyy-MM');
+
+  const monthQuery = useMonthReflectionQuery({ month: formattedMonth });
+  const todayQuery = useTodayReflectionQuery();
+  const userQuery = useUserDetailQuery();
+
+  const isAnyError =
+    monthQuery.isError || todayQuery.isError || userQuery.isError;
+
   return (
     <div className="space-y-5 pb-28">
       <PageHeader title="캘린더" />
-      <StreakBanner />
-      <CalendarMonth />
-      <SummaryCard />
 
-      {/* TODO: 바뀐 디자인 반영 확인 해야 함 */}
-      <BottomNavBar />
+      {isAnyError ? (
+        <ErrorState
+          title="캘린더 정보를 불러오지 못했어요."
+          description="잠시 후 다시 시도해주세요."
+          className="w-full max-w-none py-20"
+          retryLabel="홈으로 돌아가기"
+          onRetry={() => router.push('/')}
+        />
+      ) : (
+        <>
+          <StreakBanner data={userQuery.data} isPending={userQuery.isPending} />
+          <CalendarMonth
+            {...calendarState}
+            data={monthQuery.data}
+            isPending={monthQuery.isPending}
+          />
+          <SummaryCard
+            data={todayQuery.data}
+            isPending={todayQuery.isPending}
+          />
+          {/* TODO: 바뀐 디자인 반영 확인 해야 함 */}
+          <BottomNavBar />
+        </>
+      )}
     </div>
   );
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.13.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "motion": "^12.34.0",
     "next": "16.1.4",
     "postcss": "^8.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       motion:
         specifier: ^12.34.0
         version: 12.34.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -543,89 +546,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -725,24 +744,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.4':
     resolution: {integrity: sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.4':
     resolution: {integrity: sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.4':
     resolution: {integrity: sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.4':
     resolution: {integrity: sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==}
@@ -818,66 +841,79 @@ packages:
     resolution: {integrity: sha512-eyrr5W08Ms9uM0mLcKfM/Uzx7hjhz2bcjv8P2uynfj0yU8GGPdz8iYrBPhiLOZqahoAMB8ZiolRZPbbU2MAi6Q==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.0':
     resolution: {integrity: sha512-Xds90ITXJCNyX9pDhqf85MKWUI4lqjiPAipJ8OLp8xqI2Ehk+TCVhF9rvOoN8xTbcafow3QOThkNnrM33uCFQA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.0':
     resolution: {integrity: sha512-Xws2KA4CLvZmXjy46SQaXSejuKPhwVdaNinldoYfqruZBaJHqVo6hnRa8SDo9z7PBW5x84SH64+izmldCgbezw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.0':
     resolution: {integrity: sha512-hrKXKbX5FdaRJj7lTMusmvKbhMJSGWJ+w++4KmjiDhpTgNlhYobMvKfDoIWecy4O60K6yA4SnztGuNTQF+Lplw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.0':
     resolution: {integrity: sha512-6A+nccfSDGKsPm00d3xKcrsBcbqzCTAukjwWK6rbuAnB2bHaL3r9720HBVZ/no7+FhZLz/U3GwwZZEh6tOSI8Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.0':
     resolution: {integrity: sha512-4P1VyYUe6XAJtQH1Hh99THxr0GKMMwIXsRNOceLrJnaHTDgk1FTcTimDgneRJPvB3LqDQxUmroBclQ1S0cIJwQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.0':
     resolution: {integrity: sha512-8Vv6pLuIZCMcgXre6c3nOPhE0gjz1+nZP6T+hwWjr7sVH8k0jRkH+XnfjjOTglyMBdSKBPPz54/y1gToSKwrSQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.0':
     resolution: {integrity: sha512-r1te1M0Sm2TBVD/RxBPC6RZVwNqUTwJTA7w+C/IW5v9Ssu6xmxWEi+iJQlpBhtUiT1raJ5b48pI8tBvEjEFnFA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.0':
     resolution: {integrity: sha512-say0uMU/RaPm3CDQLxUUTF2oNWL8ysvHkAjcCzV2znxBr23kFfaxocS9qJm+NdkRhF8wtdEEAJuYcLPhSPbjuQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.0':
     resolution: {integrity: sha512-/MU7/HizQGsnBREtRpcSbSV1zfkoxSTR7wLsRmBPQ8FwUj5sykrP1MyJTvsxP5KBq9SyE6kH8UQQQwa0ASeoQQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.0':
     resolution: {integrity: sha512-Q9eh+gUGILIHEaJf66aF6a414jQbDnn29zeu0eX3dHMuysnhTvsUvZTCAyZ6tJhUjnvzBKE4FtuaYxutxRZpOg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.0':
     resolution: {integrity: sha512-OR5p5yG5OKSxHReWmwvM0P+VTPMwoBS45PXTMYaskKQqybkS3Kmugq1W+YbNWArF8/s7jQScgzXUhArzEQ7x0A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.0':
     resolution: {integrity: sha512-XeatKzo4lHDsVEbm1XDHZlhYZZSQYym6dg2X/Ko0kSFgio+KXLsxwJQprnR48GvdIKDOpqWqssC3iBCjoMcMpw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.0':
     resolution: {integrity: sha512-Lu71y78F5qOfYmubYLHPcJm74GZLU6UJ4THkf/a1K7Tz2ycwC2VUbsqbJAXaR6Bx70SRdlVrt2+n5l7F0agTUw==}
@@ -1074,24 +1110,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1314,41 +1354,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1731,6 +1779,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -2552,24 +2603,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -5171,6 +5226,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@4.1.0: {}
 
   debug@3.2.7:
     dependencies:

--- a/public/icons/calendar-day-future.svg
+++ b/public/icons/calendar-day-future.svg
@@ -1,0 +1,16 @@
+<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_g_4531_321)">
+<circle cx="19.1719" cy="19.1719" r="16" fill="#D1B7F8"/>
+</g>
+<defs>
+<filter id="filter0_g_4531_321" x="0.000559807" y="0.000559807" width="38.3426" height="38.3426" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.05000000074505806 0.05000000074505806" numOctaves="3" seed="8488" />
+<feDisplacementMap in="shape" scale="6.3426303863525391" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_4531_321">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+</defs>
+</svg>

--- a/public/icons/calendar-day-outline.svg
+++ b/public/icons/calendar-day-outline.svg
@@ -1,0 +1,16 @@
+<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_g_4574_336)">
+<circle cx="19.1719" cy="19.1719" r="16" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_g_4574_336" x="0.000559807" y="0.000559807" width="38.3426" height="38.3426" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.05000000074505806 0.05000000074505806" numOctaves="3" seed="8488" />
+<feDisplacementMap in="shape" scale="6.3426303863525391" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_4574_336">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+</defs>
+</svg>

--- a/public/icons/calendar-day-past-n.svg
+++ b/public/icons/calendar-day-past-n.svg
@@ -1,0 +1,16 @@
+<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_g_4574_311)">
+<circle cx="19.1719" cy="19.1719" r="16" fill="#EE816A"/>
+</g>
+<defs>
+<filter id="filter0_g_4574_311" x="0.000559807" y="0.000559807" width="38.3426" height="38.3426" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.05000000074505806 0.05000000074505806" numOctaves="3" seed="8488" />
+<feDisplacementMap in="shape" scale="6.3426303863525391" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_4574_311">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+</defs>
+</svg>

--- a/public/icons/calendar-day-past-p.svg
+++ b/public/icons/calendar-day-past-p.svg
@@ -1,0 +1,16 @@
+<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_g_4574_321)">
+<circle cx="19.1719" cy="19.1719" r="16" fill="#91D1F2"/>
+</g>
+<defs>
+<filter id="filter0_g_4574_321" x="0.000559807" y="0.000559807" width="38.3426" height="38.3426" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.05000000074505806 0.05000000074505806" numOctaves="3" seed="8488" />
+<feDisplacementMap in="shape" scale="6.3426303863525391" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_4574_321">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+</defs>
+</svg>

--- a/public/icons/calendar-day-present-f.svg
+++ b/public/icons/calendar-day-present-f.svg
@@ -1,0 +1,16 @@
+<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_g_4574_326)">
+<circle cx="19.1719" cy="19.1719" r="16" fill="#50C291"/>
+</g>
+<defs>
+<filter id="filter0_g_4574_326" x="0.000559807" y="0.000559807" width="38.3426" height="38.3426" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.05000000074505806 0.05000000074505806" numOctaves="3" seed="8488" />
+<feDisplacementMap in="shape" scale="6.3426303863525391" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_4574_326">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+</defs>
+</svg>

--- a/public/icons/calendar-day-present-h.svg
+++ b/public/icons/calendar-day-present-h.svg
@@ -1,0 +1,16 @@
+<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_g_4574_316)">
+<circle cx="19.1719" cy="19.1719" r="16" fill="#FDD1E4"/>
+</g>
+<defs>
+<filter id="filter0_g_4574_316" x="0.000559807" y="0.000559807" width="38.3426" height="38.3426" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.05000000074505806 0.05000000074505806" numOctaves="3" seed="8488" />
+<feDisplacementMap in="shape" scale="6.3426303863525391" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_4574_316">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+</defs>
+</svg>

--- a/public/icons/calendar-day-slate.svg
+++ b/public/icons/calendar-day-slate.svg
@@ -1,0 +1,16 @@
+<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_g_4574_331)">
+<circle cx="19.1719" cy="19.1719" r="16" fill="#313743"/>
+</g>
+<defs>
+<filter id="filter0_g_4574_331" x="0.000559807" y="0.000559807" width="38.3426" height="38.3426" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.05000000074505806 0.05000000074505806" numOctaves="3" seed="8488" />
+<feDisplacementMap in="shape" scale="6.3426303863525391" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_4574_331">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+</defs>
+</svg>

--- a/public/icons/fire.svg
+++ b/public/icons/fire.svg
@@ -1,0 +1,21 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4028_1072)">
+<g filter="url(#filter0_g_4028_1072)">
+<path d="M10.4617 0.296694C10.8883 -0.102525 11.55 -0.0970563 11.9766 0.302162C13.4859 1.71857 14.9023 3.24435 16.2258 4.89591C16.8273 4.10841 17.5109 3.24982 18.2492 2.54982C18.6813 2.14513 19.3484 2.14513 19.7805 2.55529C21.6727 4.35997 23.275 6.74435 24.4016 9.00841C25.5117 11.2397 26.25 13.5201 26.25 15.1279C26.25 22.1061 20.7922 28.0014 14 28.0014C7.13125 28.0014 1.75 22.1006 1.75 15.1225C1.75 13.0225 2.72344 10.4576 4.23281 7.92013C5.75859 5.34435 7.91328 2.65919 10.4617 0.296694ZM14.093 22.7514C15.4766 22.7514 16.7016 22.3686 17.8555 21.6029C20.1578 19.9951 20.7758 16.7795 19.3922 14.2529C19.1461 13.7608 18.5172 13.7279 18.1617 14.1436L16.7836 15.7459C16.4227 16.1615 15.7719 16.1506 15.4328 15.7186C14.5305 14.5701 12.9172 12.5194 11.9984 11.3545C11.6539 10.917 10.9977 10.9115 10.6477 11.349C8.79922 13.6733 7.86953 15.1389 7.86953 16.785C7.875 20.5311 10.6422 22.7514 14.093 22.7514Z" fill="#EE816A"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_g_4028_1072" x="0.75" y="-1" width="26.5" height="30.002" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.05000000074505806 0.05000000074505806" numOctaves="3" seed="8488" />
+<feDisplacementMap in="shape" scale="2" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_4028_1072">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+<clipPath id="clip0_4028_1072">
+<rect width="24.5" height="28" fill="white" transform="translate(1.75)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/features/calendar/CalendarMonth/CalendarDayCell/CalendarDayCell.tsx
+++ b/src/components/features/calendar/CalendarMonth/CalendarDayCell/CalendarDayCell.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import Icon from '@/src/components/ui/Icon/Icon';
+import type { IconNameType } from '@/src/components/ui/Icon/Icon.types';
+import { cn } from '@/src/lib/helpers/cn';
+
+export type CalendarDayCategoryType =
+  | 'past-negative'
+  | 'past-positive'
+  | 'present-hedonistic'
+  | 'present-fatalistic'
+  | 'future-oriented'
+  | 'slate';
+
+interface CalendarDayCellProps {
+  day: number;
+  categoryType?: CalendarDayCategoryType;
+  isFuture?: boolean;
+  hasRecord?: boolean;
+  isOutlined?: boolean;
+  onClick?: () => void;
+}
+
+const iconNameMap: Record<CalendarDayCategoryType, IconNameType> = {
+  'past-negative': 'calendarDayPastN',
+  'past-positive': 'calendarDayPastP',
+  'present-hedonistic': 'calendarDayPresentH',
+  'present-fatalistic': 'calendarDayPresentF',
+  'future-oriented': 'calendarDayFuture',
+  slate: 'calendarDaySlate',
+};
+
+const CalendarDayCell = ({
+  day,
+  categoryType,
+  isFuture = false,
+  hasRecord = false,
+  isOutlined = false,
+  onClick,
+}: CalendarDayCellProps) => {
+  const resolvedType = isFuture ? 'slate' : (categoryType ?? 'slate');
+
+  return (
+    <button type="button" onClick={onClick} className="relative h-10 w-10">
+      {isOutlined ? (
+        <Icon
+          name="calendarDayOutline"
+          decorative
+          size={40}
+          className="absolute inset-0 scale-110"
+        />
+      ) : null}
+      <Icon
+        name={iconNameMap[resolvedType]}
+        decorative
+        size={40}
+        className="absolute inset-0"
+      />
+      <span
+        className={cn(
+          'absolute inset-0 flex items-center justify-center text-body-s',
+          hasRecord ? 'text-g-900' : 'text-g-200',
+        )}
+      >
+        {day}
+      </span>
+    </button>
+  );
+};
+
+export default CalendarDayCell;

--- a/src/components/features/calendar/CalendarMonth/CalendarMonth.tsx
+++ b/src/components/features/calendar/CalendarMonth/CalendarMonth.tsx
@@ -3,7 +3,7 @@
 import { format } from 'date-fns';
 import { useMemo } from 'react';
 
-import { useMonthReflection } from '../../reflection/queries/useMonthReflection';
+import { useMonthReflectionQuery } from '../../reflection/queries/useMonthReflectionQuery';
 import { useCalendarState } from '../hooks/useCalendarState';
 import { getCategoryTypeByDate } from '../utils/getCategoryTypeByDate';
 import { mapReflectionItems } from '../utils/mapReflectionItems';
@@ -23,7 +23,7 @@ const CalendarMonth = () => {
     selectDate,
   } = useCalendarState();
   const formattedMonth = format(currentMonth, 'yyyy-MM');
-  const { data } = useMonthReflection({ month: formattedMonth });
+  const { data } = useMonthReflectionQuery({ month: formattedMonth });
 
   const categoryTypeByDate = useMemo(
     () => getCategoryTypeByDate(mapReflectionItems(data ?? [])),

--- a/src/components/features/calendar/CalendarMonth/CalendarMonth.tsx
+++ b/src/components/features/calendar/CalendarMonth/CalendarMonth.tsx
@@ -3,6 +3,9 @@
 import { format } from 'date-fns';
 import { useMemo } from 'react';
 
+import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
+import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
+
 import { useMonthReflectionQuery } from '../../reflection/queries/useMonthReflectionQuery';
 import { useCalendarState } from '../hooks/useCalendarState';
 import { getCategoryTypeByDate } from '../utils/getCategoryTypeByDate';
@@ -23,7 +26,9 @@ const CalendarMonth = () => {
     selectDate,
   } = useCalendarState();
   const formattedMonth = format(currentMonth, 'yyyy-MM');
-  const { data } = useMonthReflectionQuery({ month: formattedMonth });
+  const { data, isPending, isError } = useMonthReflectionQuery({
+    month: formattedMonth,
+  });
 
   const categoryTypeByDate = useMemo(
     () => getCategoryTypeByDate(mapReflectionItems(data ?? [])),
@@ -40,15 +45,32 @@ const CalendarMonth = () => {
 
       <CalendarMonthWeekdays />
 
-      {/* TODO: 아이콘 바뀐걸로 변경해야 함. */}
-      <CalendarMonthGrid
-        days={days}
-        currentMonth={currentMonth}
-        selectedDate={selectedDate}
-        today={today}
-        categoryTypeByDate={categoryTypeByDate}
-        selectDate={selectDate}
-      />
+      {isPending ? (
+        <div className="grid grid-cols-7 gap-2">
+          {Array.from({ length: 42 }).map((_, index) => (
+            <Skeleton
+              key={index}
+              className="h-10 w-10 rounded-full bg-g-500"
+              ariaLabel="캘린더 로딩 중"
+            />
+          ))}
+        </div>
+      ) : isError ? (
+        <ErrorState
+          title="이번 달 회고를 불러오지 못했어요."
+          className="w-full h-70 py-10"
+        />
+      ) : (
+        // TODO: 아이콘 바뀐걸로 변경해야 함.
+        <CalendarMonthGrid
+          days={days}
+          currentMonth={currentMonth}
+          selectedDate={selectedDate}
+          today={today}
+          categoryTypeByDate={categoryTypeByDate}
+          selectDate={selectDate}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/features/calendar/CalendarMonth/CalendarMonth.tsx
+++ b/src/components/features/calendar/CalendarMonth/CalendarMonth.tsx
@@ -1,35 +1,34 @@
 'use client';
 
-import { format } from 'date-fns';
 import { useMemo } from 'react';
 
-import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
 import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
 
-import { useMonthReflectionQuery } from '../../reflection/queries/useMonthReflectionQuery';
-import { useCalendarState } from '../hooks/useCalendarState';
+import type { GetMonthReflectionResponse } from '../../reflection/queries/useMonthReflectionQuery';
+import type { UseCalendarStateResult } from '../hooks/useCalendarState';
 import { getCategoryTypeByDate } from '../utils/getCategoryTypeByDate';
 import { mapReflectionItems } from '../utils/mapReflectionItems';
 import CalendarMonthGrid from './CalendarMonthGrid/CalendarMonthGrid';
 import CalendarMonthHeader from './CalendarMonthHeader/CalendarMonthHeader';
 import CalendarMonthWeekdays from './CalendarMonthWeekdays/CalendarMonthWeekdays';
 
-const CalendarMonth = () => {
-  const {
-    today,
-    currentMonth,
-    currentMonthLabel,
-    selectedDate,
-    days,
-    goPrevMonth,
-    goNextMonth,
-    selectDate,
-  } = useCalendarState();
-  const formattedMonth = format(currentMonth, 'yyyy-MM');
-  const { data, isPending, isError } = useMonthReflectionQuery({
-    month: formattedMonth,
-  });
+interface CalendarMonthProps extends UseCalendarStateResult {
+  data?: GetMonthReflectionResponse;
+  isPending: boolean;
+}
 
+const CalendarMonth = ({
+  today,
+  currentMonth,
+  currentMonthLabel,
+  selectedDate,
+  days,
+  goPrevMonth,
+  goNextMonth,
+  selectDate,
+  data,
+  isPending,
+}: CalendarMonthProps) => {
   const categoryTypeByDate = useMemo(
     () => getCategoryTypeByDate(mapReflectionItems(data ?? [])),
     [data],
@@ -55,11 +54,6 @@ const CalendarMonth = () => {
             />
           ))}
         </div>
-      ) : isError ? (
-        <ErrorState
-          title="이번 달 회고를 불러오지 못했어요."
-          className="w-full h-70 py-10"
-        />
       ) : (
         // TODO: 아이콘 바뀐걸로 변경해야 함.
         <CalendarMonthGrid

--- a/src/components/features/calendar/CalendarMonth/CalendarMonth.tsx
+++ b/src/components/features/calendar/CalendarMonth/CalendarMonth.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { format } from 'date-fns';
+import { useMemo } from 'react';
+
+import { useMonthReflection } from '../../reflection/queries/useMonthReflection';
+import { useCalendarState } from '../hooks/useCalendarState';
+import { getCategoryTypeByDate } from '../utils/getCategoryTypeByDate';
+import { mapReflectionItems } from '../utils/mapReflectionItems';
+import CalendarMonthGrid from './CalendarMonthGrid/CalendarMonthGrid';
+import CalendarMonthHeader from './CalendarMonthHeader/CalendarMonthHeader';
+import CalendarMonthWeekdays from './CalendarMonthWeekdays/CalendarMonthWeekdays';
+
+const CalendarMonth = () => {
+  const {
+    today,
+    currentMonth,
+    currentMonthLabel,
+    selectedDate,
+    days,
+    goPrevMonth,
+    goNextMonth,
+    selectDate,
+  } = useCalendarState();
+  const formattedMonth = format(currentMonth, 'yyyy-MM');
+  const { data } = useMonthReflection({ month: formattedMonth });
+
+  const categoryTypeByDate = useMemo(
+    () => getCategoryTypeByDate(mapReflectionItems(data ?? [])),
+    [data],
+  );
+
+  return (
+    <div className="space-y-3">
+      <CalendarMonthHeader
+        currentMonthLabel={currentMonthLabel}
+        goPrevMonth={goPrevMonth}
+        goNextMonth={goNextMonth}
+      />
+
+      <CalendarMonthWeekdays />
+
+      {/* TODO: 아이콘 바뀐걸로 변경해야 함. */}
+      <CalendarMonthGrid
+        days={days}
+        currentMonth={currentMonth}
+        selectedDate={selectedDate}
+        today={today}
+        categoryTypeByDate={categoryTypeByDate}
+        selectDate={selectDate}
+      />
+    </div>
+  );
+};
+
+export default CalendarMonth;

--- a/src/components/features/calendar/CalendarMonth/CalendarMonthGrid/CalendarMonthGrid.tsx
+++ b/src/components/features/calendar/CalendarMonth/CalendarMonthGrid/CalendarMonthGrid.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import {
+  type CalendarDayCellType,
+  getCalendarDayCells,
+} from '../../utils/getCalendarDayCells';
+import type { CalendarDayCategoryType } from '../CalendarDayCell/CalendarDayCell';
+import CalendarDayCell from '../CalendarDayCell/CalendarDayCell';
+
+interface CalendarMonthGridProps {
+  days: Date[];
+  currentMonth: Date;
+  selectedDate: Date | null;
+  today: Date;
+  categoryTypeByDate: Map<string, CalendarDayCategoryType>;
+  selectDate: (date: Date) => void;
+}
+
+const CalendarMonthGrid = ({
+  days,
+  currentMonth,
+  selectedDate,
+  today,
+  categoryTypeByDate,
+  selectDate,
+}: CalendarMonthGridProps) => {
+  const dayCells: CalendarDayCellType[] = getCalendarDayCells({
+    days,
+    currentMonth,
+    selectedDate,
+    today,
+    categoryTypeByDate,
+  });
+
+  const handleDateSelect = (date: Date) => {
+    selectDate(date);
+  };
+
+  return (
+    <ul className="grid grid-cols-7 gap-y-2">
+      {dayCells.map((dayCell) => {
+        return (
+          <li key={dayCell.key} className="flex justify-center">
+            {dayCell.isCurrentMonth ? (
+              <CalendarDayCell
+                day={dayCell.blobProps.day}
+                categoryType={dayCell.categoryType}
+                isFuture={dayCell.isFuture}
+                hasRecord={dayCell.blobProps.hasRecord}
+                isOutlined={dayCell.blobProps.isOutlined}
+                onClick={() => handleDateSelect(dayCell.date)}
+              />
+            ) : (
+              <span aria-hidden className="h-10 w-10" />
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default CalendarMonthGrid;

--- a/src/components/features/calendar/CalendarMonth/CalendarMonthHeader/CalendarMonthHeader.tsx
+++ b/src/components/features/calendar/CalendarMonth/CalendarMonthHeader/CalendarMonthHeader.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Icon from '@/src/components/ui/Icon/Icon';
+
+interface CalendarMonthHeaderProps {
+  currentMonthLabel: string;
+  goPrevMonth: () => void;
+  goNextMonth: () => void;
+}
+
+const CalendarMonthHeader = ({
+  currentMonthLabel,
+  goPrevMonth,
+  goNextMonth,
+}: CalendarMonthHeaderProps) => {
+  return (
+    <div className="flex items-center justify-center gap-4">
+      <button
+        type="button"
+        onClick={goPrevMonth}
+        aria-label="이전 달"
+        className="flex h-8 w-8 items-center justify-center rounded-full text-g-80 hover:bg-g-500"
+      >
+        <Icon name="chevronLeft" decorative size={24} />
+      </button>
+      <p className="text-center text-heading-h3">{currentMonthLabel}</p>
+      <button
+        type="button"
+        onClick={goNextMonth}
+        aria-label="다음 달"
+        className="flex h-8 w-8 items-center justify-center rounded-full text-g-80 hover:bg-g-500"
+      >
+        <Icon name="chevronLeft" decorative className="rotate-180" size={24} />
+      </button>
+    </div>
+  );
+};
+
+export default CalendarMonthHeader;

--- a/src/components/features/calendar/CalendarMonth/CalendarMonthWeekdays/CalendarMonthWeekdays.tsx
+++ b/src/components/features/calendar/CalendarMonth/CalendarMonthWeekdays/CalendarMonthWeekdays.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+const WEEKDAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+const CalendarMonthWeekdays = () => {
+  return (
+    <ul className="grid grid-cols-7 text-center text-body-s text-g-20">
+      {WEEKDAY_LABELS.map((label) => (
+        <li key={label} className="py-1">
+          {label}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default CalendarMonthWeekdays;

--- a/src/components/features/calendar/StreakBanner/StreackBanner.tsx
+++ b/src/components/features/calendar/StreakBanner/StreackBanner.tsx
@@ -1,12 +1,34 @@
 'use client';
 
 import Card from '@/src/components/ui/Card/Card';
+import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
 import Icon from '@/src/components/ui/Icon/Icon';
+import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
 
 import { useUserDetailQuery } from '../../users/queries/useUserDetailQuery';
 
 const StreakBanner = () => {
-  const { data } = useUserDetailQuery();
+  const { data, isPending, isError } = useUserDetailQuery();
+
+  if (isPending) {
+    return (
+      <Card className="bg-linear-to-r from-y-50 to-primary py-2">
+        <Skeleton
+          className="h-8 w-full bg-g-300/30"
+          ariaLabel="연속 기록 로딩 중"
+        />
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Card className="bg-linear-to-r from-y-50 to-primary py-2">
+        <ErrorState title="기록을 불러오지 못했어요." className="text-g-900" />
+      </Card>
+    );
+  }
+
   const currentStreak = data?.streakDays ?? 0;
 
   return (

--- a/src/components/features/calendar/StreakBanner/StreackBanner.tsx
+++ b/src/components/features/calendar/StreakBanner/StreackBanner.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import Card from '@/src/components/ui/Card/Card';
-import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
 import Icon from '@/src/components/ui/Icon/Icon';
 import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
 
-import { useUserDetailQuery } from '../../users/queries/useUserDetailQuery';
+import type { UserDetailResponse } from '../../users/queries/useUserDetailQuery';
 
-const StreakBanner = () => {
-  const { data, isPending, isError } = useUserDetailQuery();
+interface StreakBannerProps {
+  data?: UserDetailResponse;
+  isPending: boolean;
+}
 
+const StreakBanner = ({ data, isPending }: StreakBannerProps) => {
   if (isPending) {
     return (
       <Card className="bg-linear-to-r from-y-50 to-primary py-2">
@@ -17,14 +19,6 @@ const StreakBanner = () => {
           className="h-8 w-full bg-g-300/30"
           ariaLabel="연속 기록 로딩 중"
         />
-      </Card>
-    );
-  }
-
-  if (isError) {
-    return (
-      <Card className="bg-linear-to-r from-y-50 to-primary py-2">
-        <ErrorState title="기록을 불러오지 못했어요." className="text-g-900" />
       </Card>
     );
   }

--- a/src/components/features/calendar/StreakBanner/StreackBanner.tsx
+++ b/src/components/features/calendar/StreakBanner/StreackBanner.tsx
@@ -1,9 +1,14 @@
+'use client';
+
 import Card from '@/src/components/ui/Card/Card';
 import Icon from '@/src/components/ui/Icon/Icon';
 
+import { useUserDetailQuery } from '../../users/queries/useUserDetailQuery';
+
 const StreakBanner = () => {
-  // TODO: API에서 연속 기록 일수 받아오기
-  const currentStreak = 5;
+  const { data } = useUserDetailQuery();
+  const currentStreak = data?.streakDays ?? 0;
+
   return (
     <Card className="flex items-center justify-start gap-3 bg-linear-to-r from-y-50 to-primary text-g-900 py-2">
       <Icon name="fire" size={28} />

--- a/src/components/features/calendar/StreakBanner/StreackBanner.tsx
+++ b/src/components/features/calendar/StreakBanner/StreackBanner.tsx
@@ -1,0 +1,18 @@
+import Card from '@/src/components/ui/Card/Card';
+import Icon from '@/src/components/ui/Icon/Icon';
+
+const StreakBanner = () => {
+  // TODO: API에서 연속 기록 일수 받아오기
+  const currentStreak = 5;
+  return (
+    <Card className="flex items-center justify-start gap-3 bg-linear-to-r from-y-50 to-primary text-g-900 py-2">
+      <Icon name="fire" size={28} />
+      <div className="flex items-center gap-1">
+        <span className="text-heading-h2">{currentStreak}</span>
+        <span className="text-body-m text-g-300">일 연속 기록 중이에요!</span>
+      </div>
+    </Card>
+  );
+};
+
+export default StreakBanner;

--- a/src/components/features/calendar/SummaryCard/SummaryCard.tsx
+++ b/src/components/features/calendar/SummaryCard/SummaryCard.tsx
@@ -1,23 +1,46 @@
 'use client';
 
 import Card from '@/src/components/ui/Card/Card';
+import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
 import Icon from '@/src/components/ui/Icon/Icon';
+import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
 import { cn } from '@/src/lib/helpers/cn';
 
 import { useTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
 import { CATEGORY_CARD_CLASS_MAP } from '../constants/categoryCardClassMap';
 
 const SummaryCard = () => {
-  const { data } = useTodayReflectionQuery();
-
-  const todayQuestion = data?.question.content ?? '오늘의 질문이 없습니다.';
-  const todayReflection = data?.content ?? '오늘의 회고 답변이 없습니다.';
+  const { data, isPending, isError } = useTodayReflectionQuery();
   const todayCategory = data?.question.category;
 
   const handleCardClick = () => {
     // TODO: 카드 클릭 시 오늘의 회고 상세 페이지로 이동하도록 구현 필요
-    console.log('오늘의 질문 카드 클릭됨');
   };
+
+  if (isPending) {
+    return (
+      <Card className="rounded-2xl bg-g-500 p-5">
+        <div className="space-y-4">
+          <Skeleton className="h-6 w-4/5" ariaLabel="오늘의 질문 로딩 중" />
+          <Skeleton className="h-4 w-full" ariaLabel="오늘의 회고 로딩 중" />
+        </div>
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Card className="rounded-2xl bg-g-500 p-5">
+        <ErrorState
+          title="오늘 회고를 불러오지 못했어요."
+          className="w-full max-w-none"
+        />
+      </Card>
+    );
+  }
+
+  const todayQuestion = data?.question.content ?? '오늘의 질문이 없습니다.';
+  const todayReflection = data?.content ?? '오늘의 회고 답변이 없습니다.';
 
   return (
     // TODO: 디자인 물어보고 카드 스타일 업데이트 필요,
@@ -34,7 +57,14 @@ const SummaryCard = () => {
         className="w-full"
       >
         <div className="flex items-start justify-between gap-4">
-          <p className="text-left text-body-m text-g-900">{todayQuestion}</p>
+          <p
+            className={cn(
+              'text-left text-body-m',
+              data ? 'text-g-900' : 'text-g-0',
+            )}
+          >
+            {todayQuestion}
+          </p>
           <Icon name="chevronLeft" size={24} className="pt-1 rotate-180" />
         </div>
       </button>

--- a/src/components/features/calendar/SummaryCard/SummaryCard.tsx
+++ b/src/components/features/calendar/SummaryCard/SummaryCard.tsx
@@ -1,16 +1,19 @@
 'use client';
 
 import Card from '@/src/components/ui/Card/Card';
-import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
 import Icon from '@/src/components/ui/Icon/Icon';
 import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
 import { cn } from '@/src/lib/helpers/cn';
 
-import { useTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
+import type { GetTodayReflectionResponse } from '../../reflection/queries/useTodayReflectionQuery';
 import { CATEGORY_CARD_CLASS_MAP } from '../constants/categoryCardClassMap';
 
-const SummaryCard = () => {
-  const { data, isPending, isError } = useTodayReflectionQuery();
+interface SummaryCardProps {
+  data?: GetTodayReflectionResponse;
+  isPending: boolean;
+}
+
+const SummaryCard = ({ data, isPending }: SummaryCardProps) => {
   const todayCategory = data?.question.category;
 
   const handleCardClick = () => {
@@ -24,17 +27,6 @@ const SummaryCard = () => {
           <Skeleton className="h-6 w-4/5" ariaLabel="오늘의 질문 로딩 중" />
           <Skeleton className="h-4 w-full" ariaLabel="오늘의 회고 로딩 중" />
         </div>
-      </Card>
-    );
-  }
-
-  if (isError) {
-    return (
-      <Card className="rounded-2xl bg-g-500 p-5">
-        <ErrorState
-          title="오늘 회고를 불러오지 못했어요."
-          className="w-full max-w-none"
-        />
       </Card>
     );
   }

--- a/src/components/features/calendar/SummaryCard/SummaryCard.tsx
+++ b/src/components/features/calendar/SummaryCard/SummaryCard.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Card from '@/src/components/ui/Card/Card';
+import Icon from '@/src/components/ui/Icon/Icon';
+
+const SummaryCard = () => {
+  const handleCardClick = () => {
+    // TODO: 카드 클릭 시 오늘의 회고 상세 페이지로 이동하도록 구현 필요
+    console.log('오늘의 질문 카드 클릭됨');
+  };
+
+  return (
+    // TODO: 카드 배경은 감정상태 색상의 50컬러, Stroke는 감정상태 색상의 200컬러: API에서 오늘의 category 받아와야 함.
+    <Card className="rounded-2xl bg-g-500 p-5">
+      <button
+        type="button"
+        onClick={handleCardClick}
+        aria-label="오늘 질문 상세 보기"
+        className="w-full"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <p className="text-left text-body-m text-g-0">
+            {/* TODO: API에서 오늘의 질문 받아오기; */}
+            오늘 하루 중 가장 재미있었던 순간은 언제였나요?
+          </p>
+          <Icon name="chevronLeft" size={24} className="pt-1 rotate-180" />
+        </div>
+      </button>
+      <p className="pt-4 line-clamp-2 text-body-s text-g-80">
+        {/* TODO: API에서 오늘의 회고 답변 받아오기 */}
+        오늘 하루 중 가장 즐거웠던 순간은 점심시간이었습니다. 팀원들과 회사
+        뒤편에 새로 생긴 퓨전 한식당을 찾았는데, 아직 입소문이 덜 났는지 손님이
+        우리 테이블밖에 없어 마치 가게를 통째로 빌린 기분이었습니다. 조용한
+        분위기 덕분에 음식의 맛을 음미하기 좋았고, 무엇보다 한가해진 사장님이
+        저희 테이블을 전담 마크해주신 덕에 식사 내내 유쾌한 시간을 보냈습니다.
+        부장님이 매운 맛에 땀을 흘리시자마자 기다렸다는 듯 얼음물을 챙겨주시는
+        사장님의 센스에 다들 빵 터졌네요. 북적이는 구내식당을 벗어나 우리끼리
+        오붓하고 느긋하게 웃을 수 있었던 그 1시간이 오늘 저에게는 최고의
+        힐링이었습니다.
+      </p>
+    </Card>
+  );
+};
+
+export default SummaryCard;

--- a/src/components/features/calendar/SummaryCard/SummaryCard.tsx
+++ b/src/components/features/calendar/SummaryCard/SummaryCard.tsx
@@ -2,8 +2,10 @@
 
 import Card from '@/src/components/ui/Card/Card';
 import Icon from '@/src/components/ui/Icon/Icon';
+import { cn } from '@/src/lib/helpers/cn';
 
 import { useTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
+import { CATEGORY_CARD_CLASS_MAP } from '../constants/categoryCardClassMap';
 
 const SummaryCard = () => {
   const { data } = useTodayReflectionQuery();
@@ -18,8 +20,13 @@ const SummaryCard = () => {
   };
 
   return (
-    // TODO: 카드 배경은 감정상태 색상의 50컬러, Stroke는 감정상태 색상의 200컬러: API에서 오늘의 category 받아와야 함.
-    <Card className="rounded-2xl bg-g-500 p-5">
+    // TODO: 디자인 물어보고 카드 스타일 업데이트 필요,
+    <Card
+      className={cn(
+        'rounded-2xl bg-g-500 p-5',
+        todayCategory && CATEGORY_CARD_CLASS_MAP[todayCategory],
+      )}
+    >
       <button
         type="button"
         onClick={handleCardClick}

--- a/src/components/features/calendar/SummaryCard/SummaryCard.tsx
+++ b/src/components/features/calendar/SummaryCard/SummaryCard.tsx
@@ -3,7 +3,15 @@
 import Card from '@/src/components/ui/Card/Card';
 import Icon from '@/src/components/ui/Icon/Icon';
 
+import { useTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
+
 const SummaryCard = () => {
+  const { data } = useTodayReflectionQuery();
+
+  const todayQuestion = data?.question.content ?? '오늘의 질문이 없습니다.';
+  const todayReflection = data?.content ?? '오늘의 회고 답변이 없습니다.';
+  const todayCategory = data?.question.category;
+
   const handleCardClick = () => {
     // TODO: 카드 클릭 시 오늘의 회고 상세 페이지로 이동하도록 구현 필요
     console.log('오늘의 질문 카드 클릭됨');
@@ -19,24 +27,12 @@ const SummaryCard = () => {
         className="w-full"
       >
         <div className="flex items-start justify-between gap-4">
-          <p className="text-left text-body-m text-g-0">
-            {/* TODO: API에서 오늘의 질문 받아오기; */}
-            오늘 하루 중 가장 재미있었던 순간은 언제였나요?
-          </p>
+          <p className="text-left text-body-m text-g-900">{todayQuestion}</p>
           <Icon name="chevronLeft" size={24} className="pt-1 rotate-180" />
         </div>
       </button>
       <p className="pt-4 line-clamp-2 text-body-s text-g-80">
-        {/* TODO: API에서 오늘의 회고 답변 받아오기 */}
-        오늘 하루 중 가장 즐거웠던 순간은 점심시간이었습니다. 팀원들과 회사
-        뒤편에 새로 생긴 퓨전 한식당을 찾았는데, 아직 입소문이 덜 났는지 손님이
-        우리 테이블밖에 없어 마치 가게를 통째로 빌린 기분이었습니다. 조용한
-        분위기 덕분에 음식의 맛을 음미하기 좋았고, 무엇보다 한가해진 사장님이
-        저희 테이블을 전담 마크해주신 덕에 식사 내내 유쾌한 시간을 보냈습니다.
-        부장님이 매운 맛에 땀을 흘리시자마자 기다렸다는 듯 얼음물을 챙겨주시는
-        사장님의 센스에 다들 빵 터졌네요. 북적이는 구내식당을 벗어나 우리끼리
-        오붓하고 느긋하게 웃을 수 있었던 그 1시간이 오늘 저에게는 최고의
-        힐링이었습니다.
+        {todayReflection}
       </p>
     </Card>
   );

--- a/src/components/features/calendar/constants/categoryCardClassMap.ts
+++ b/src/components/features/calendar/constants/categoryCardClassMap.ts
@@ -1,0 +1,7 @@
+export const CATEGORY_CARD_CLASS_MAP = {
+  PAST_NEGATIVE: 'bg-r-50 border border-[var(--color-r-200)]',
+  PAST_POSITIVE: 'bg-b-50 border border-b-200',
+  PRESENT_HEDONISTIC: 'bg-p-50 border border-p-200',
+  PRESENT_FATALISTIC: 'bg-gr-50 border border-gr-200',
+  FUTURE: 'bg-v-50 border border-v-200',
+} as const;

--- a/src/components/features/calendar/hooks/useCalendarState.ts
+++ b/src/components/features/calendar/hooks/useCalendarState.ts
@@ -9,7 +9,7 @@ import {
 } from 'date-fns';
 import { useMemo, useState } from 'react';
 
-interface UseCalendarStateResult {
+export interface UseCalendarStateResult {
   today: Date;
   currentMonth: Date;
   currentMonthLabel: string;

--- a/src/components/features/calendar/hooks/useCalendarState.ts
+++ b/src/components/features/calendar/hooks/useCalendarState.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import {
+  addDays,
+  addMonths,
+  format,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns';
+import { useMemo, useState } from 'react';
+
+interface UseCalendarStateResult {
+  today: Date;
+  currentMonth: Date;
+  currentMonthLabel: string;
+  selectedDate: Date | null;
+  days: Date[];
+  goPrevMonth: () => void;
+  goNextMonth: () => void;
+  selectDate: (date: Date) => void;
+}
+
+export const useCalendarState = (): UseCalendarStateResult => {
+  // 오늘 날짜(초기 렌더에서 한 번만 계산)
+  const today = useMemo(() => new Date(), []);
+
+  // 캘린더 기준 월(오늘이 속한 달의 1일)
+  const [currentMonth, setCurrentMonth] = useState(() => startOfMonth(today));
+
+  // 사용자가 선택한 날짜 (없으면 null)
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  // 헤더에 표시할 월 라벨
+  const currentMonthLabel = useMemo(
+    () => format(currentMonth, 'yyyy.MM'),
+    [currentMonth],
+  );
+
+  // 6주 고정 그리드(42칸)를 Date 배열로 생성
+  const days = useMemo(() => {
+    // 현재 월의 시작일이 속한 주의 시작(일요일)을 계산
+    const gridStart = startOfWeek(currentMonth, {
+      weekStartsOn: 0,
+    });
+
+    return Array.from({ length: 42 }, (_, index) => addDays(gridStart, index));
+  }, [currentMonth]);
+
+  const goPrevMonth = () => {
+    setCurrentMonth((month) => startOfMonth(addMonths(month, -1)));
+  };
+
+  const goNextMonth = () => {
+    setCurrentMonth((month) => startOfMonth(addMonths(month, 1)));
+  };
+
+  const selectDate = (date: Date) => {
+    setSelectedDate(date);
+  };
+
+  return {
+    today,
+    currentMonth,
+    currentMonthLabel,
+    selectedDate,
+    days,
+    goPrevMonth,
+    goNextMonth,
+    selectDate,
+  };
+};

--- a/src/components/features/calendar/hooks/useCalendarState.ts
+++ b/src/components/features/calendar/hooks/useCalendarState.ts
@@ -48,10 +48,12 @@ export const useCalendarState = (): UseCalendarStateResult => {
 
   const goPrevMonth = () => {
     setCurrentMonth((month) => startOfMonth(addMonths(month, -1)));
+    setSelectedDate(null);
   };
 
   const goNextMonth = () => {
     setCurrentMonth((month) => startOfMonth(addMonths(month, 1)));
+    setSelectedDate(null);
   };
 
   const selectDate = (date: Date) => {

--- a/src/components/features/calendar/utils/getCalendarDayCells.ts
+++ b/src/components/features/calendar/utils/getCalendarDayCells.ts
@@ -10,7 +10,7 @@ interface GetCalendarDayCellsParams {
   categoryTypeByDate: Map<string, CalendarDayCategoryType>;
 }
 
-interface CalendarDayBlobProps {
+interface CalendarDayCellProps {
   day: number;
   hasRecord: boolean;
   isOutlined: boolean;
@@ -22,7 +22,7 @@ export interface CalendarDayCellType {
   date: Date;
   isFuture: boolean;
   categoryType: CalendarDayCategoryType | undefined;
-  blobProps: CalendarDayBlobProps;
+  blobProps: CalendarDayCellProps;
 }
 
 /**

--- a/src/components/features/calendar/utils/getCalendarDayCells.ts
+++ b/src/components/features/calendar/utils/getCalendarDayCells.ts
@@ -1,6 +1,6 @@
 import { format, isAfter, isSameDay, isSameMonth, startOfDay } from 'date-fns';
 
-import type { CalendarDayCategoryType } from '../CalendarDayCell/CalendarDayCell';
+import type { CalendarDayCategoryType } from '../CalendarMonth/CalendarDayCell/CalendarDayCell';
 
 interface GetCalendarDayCellsParams {
   days: Date[];

--- a/src/components/features/calendar/utils/getCalendarDayCells.ts
+++ b/src/components/features/calendar/utils/getCalendarDayCells.ts
@@ -1,0 +1,64 @@
+import { format, isAfter, isSameDay, isSameMonth, startOfDay } from 'date-fns';
+
+import type { CalendarDayBlobType } from '../CalendarDayBlob/CalendarDayBlob';
+
+interface GetCalendarDayCellsParams {
+  days: Date[];
+  currentMonth: Date;
+  selectedDate: Date | null;
+  today: Date;
+  categoryTypeByDate: Map<string, CalendarDayBlobType>;
+}
+
+interface CalendarDayBlobProps {
+  day: number;
+  hasRecord: boolean;
+  isOutlined: boolean;
+}
+
+export interface CalendarDayCell {
+  key: string;
+  isCurrentMonth: boolean;
+  date: Date;
+  isFuture: boolean;
+  categoryType: CalendarDayBlobType | undefined;
+  blobProps: CalendarDayBlobProps;
+}
+
+/**
+ * 42칸 캘린더 날짜 배열을 화면 렌더링용 셀 데이터로 변환
+ */
+export const getCalendarDayCells = ({
+  days,
+  currentMonth,
+  selectedDate,
+  today,
+  categoryTypeByDate,
+}: GetCalendarDayCellsParams): CalendarDayCell[] => {
+  const todayStart = startOfDay(today);
+
+  return days.map((day) => {
+    const isCurrentMonth = isSameMonth(day, currentMonth);
+    const isSelected = selectedDate ? isSameDay(day, selectedDate) : false;
+    const dayStart = startOfDay(day);
+    const isToday = isSameDay(dayStart, todayStart);
+    const isOutlined = selectedDate ? isSelected : isToday;
+    const isFuture = isAfter(dayStart, todayStart);
+    const dayKey = format(day, 'yyyy-MM-dd');
+    const categoryType = categoryTypeByDate.get(dayKey);
+    const hasRecord = Boolean(categoryType);
+
+    return {
+      key: day.toISOString(),
+      isCurrentMonth,
+      date: day,
+      isFuture,
+      categoryType,
+      blobProps: {
+        day: day.getDate(),
+        hasRecord,
+        isOutlined,
+      },
+    };
+  });
+};

--- a/src/components/features/calendar/utils/getCalendarDayCells.ts
+++ b/src/components/features/calendar/utils/getCalendarDayCells.ts
@@ -1,6 +1,6 @@
 import { format, isAfter, isSameDay, isSameMonth, startOfDay } from 'date-fns';
 
-import type { CalendarDayCategoryType } from '../CalendarDayBlob/CalendarDayBlob';
+import type { CalendarDayCategoryType } from '../CalendarDayCell/CalendarDayCell';
 
 interface GetCalendarDayCellsParams {
   days: Date[];

--- a/src/components/features/calendar/utils/getCalendarDayCells.ts
+++ b/src/components/features/calendar/utils/getCalendarDayCells.ts
@@ -16,7 +16,7 @@ interface CalendarDayBlobProps {
   isOutlined: boolean;
 }
 
-export interface CalendarDayCell {
+export interface CalendarDayCellType {
   key: string;
   isCurrentMonth: boolean;
   date: Date;
@@ -34,7 +34,7 @@ export const getCalendarDayCells = ({
   selectedDate,
   today,
   categoryTypeByDate,
-}: GetCalendarDayCellsParams): CalendarDayCell[] => {
+}: GetCalendarDayCellsParams): CalendarDayCellType[] => {
   const todayStart = startOfDay(today);
 
   return days.map((day) => {

--- a/src/components/features/calendar/utils/getCalendarDayCells.ts
+++ b/src/components/features/calendar/utils/getCalendarDayCells.ts
@@ -1,13 +1,13 @@
 import { format, isAfter, isSameDay, isSameMonth, startOfDay } from 'date-fns';
 
-import type { CalendarDayBlobType } from '../CalendarDayBlob/CalendarDayBlob';
+import type { CalendarDayCategoryType } from '../CalendarDayBlob/CalendarDayBlob';
 
 interface GetCalendarDayCellsParams {
   days: Date[];
   currentMonth: Date;
   selectedDate: Date | null;
   today: Date;
-  categoryTypeByDate: Map<string, CalendarDayBlobType>;
+  categoryTypeByDate: Map<string, CalendarDayCategoryType>;
 }
 
 interface CalendarDayBlobProps {
@@ -21,7 +21,7 @@ export interface CalendarDayCellType {
   isCurrentMonth: boolean;
   date: Date;
   isFuture: boolean;
-  categoryType: CalendarDayBlobType | undefined;
+  categoryType: CalendarDayCategoryType | undefined;
   blobProps: CalendarDayBlobProps;
 }
 

--- a/src/components/features/calendar/utils/getCategoryTypeByDate.ts
+++ b/src/components/features/calendar/utils/getCategoryTypeByDate.ts
@@ -1,4 +1,4 @@
-import type { CalendarDayCategoryType } from '../CalendarDayBlob/CalendarDayBlob';
+import type { CalendarDayCategoryType } from '../CalendarDayCell/CalendarDayCell';
 import type { ReflectionCategoryItem } from './mapReflectionItems';
 
 const CATEGORY_TO_BLOB_TYPE: Record<string, CalendarDayCategoryType> = {

--- a/src/components/features/calendar/utils/getCategoryTypeByDate.ts
+++ b/src/components/features/calendar/utils/getCategoryTypeByDate.ts
@@ -1,4 +1,4 @@
-import type { CalendarDayCategoryType } from '../CalendarDayCell/CalendarDayCell';
+import type { CalendarDayCategoryType } from '../CalendarMonth/CalendarDayCell/CalendarDayCell';
 import type { ReflectionCategoryItem } from './mapReflectionItems';
 
 const CATEGORY_TO_BLOB_TYPE: Record<string, CalendarDayCategoryType> = {

--- a/src/components/features/calendar/utils/getRecordedTypeByDate.ts
+++ b/src/components/features/calendar/utils/getRecordedTypeByDate.ts
@@ -1,7 +1,7 @@
-import type { CalendarDayBlobType } from '../CalendarDayBlob/CalendarDayBlob';
+import type { CalendarDayCategoryType } from '../CalendarDayBlob/CalendarDayBlob';
 import type { ReflectionCategoryItem } from './mapReflectionItems';
 
-const CATEGORY_TO_BLOB_TYPE: Record<string, CalendarDayBlobType> = {
+const CATEGORY_TO_BLOB_TYPE: Record<string, CalendarDayCategoryType> = {
   PAST_NEGATIVE: 'past-negative',
   PAST_POSITIVE: 'past-positive',
   PRESENT_HEDONISTIC: 'present-hedonistic',
@@ -11,12 +11,12 @@ const CATEGORY_TO_BLOB_TYPE: Record<string, CalendarDayBlobType> = {
 
 /**
  * 회고 목록을 날짜별 카테고리 타입 맵으로 변환
- * key는 `yyyy-MM-dd` 형식이며, value는 `CalendarDayBlobType`
+ * key는 `yyyy-MM-dd` 형식이며, value는 `CalendarDayCategoryType`
  */
 export const getCategoryTypeByDate = (
   data: ReflectionCategoryItem[],
-): Map<string, CalendarDayBlobType> => {
-  const categoryTypeByDate = new Map<string, CalendarDayBlobType>();
+): Map<string, CalendarDayCategoryType> => {
+  const categoryTypeByDate = new Map<string, CalendarDayCategoryType>();
 
   for (const { category, createdAt } of data) {
     const type = CATEGORY_TO_BLOB_TYPE[category];

--- a/src/components/features/calendar/utils/getRecordedTypeByDate.ts
+++ b/src/components/features/calendar/utils/getRecordedTypeByDate.ts
@@ -1,0 +1,30 @@
+import type { CalendarDayBlobType } from '../CalendarDayBlob/CalendarDayBlob';
+import type { ReflectionCategoryItem } from './mapReflectionItems';
+
+const CATEGORY_TO_BLOB_TYPE: Record<string, CalendarDayBlobType> = {
+  PAST_NEGATIVE: 'past-negative',
+  PAST_POSITIVE: 'past-positive',
+  PRESENT_HEDONISTIC: 'present-hedonistic',
+  PRESENT_FATALISTIC: 'present-fatalistic',
+  FUTURE: 'future-oriented',
+};
+
+/**
+ * 회고 목록을 날짜별 캘린더 아이콘 타입 맵으로 변환
+ * key는 `yyyy-MM-dd` 형식이며, value는 `CalendarDayBlobType`
+ */
+export const getRecordedTypeByDate = (
+  data: ReflectionCategoryItem[],
+): Map<string, CalendarDayBlobType> => {
+  const recordedTypeByDate = new Map<string, CalendarDayBlobType>();
+
+  for (const { category, createdAt } of data) {
+    const type = CATEGORY_TO_BLOB_TYPE[category];
+    if (!type) continue;
+
+    const dateKey = createdAt.slice(0, 10);
+    recordedTypeByDate.set(dateKey, type);
+  }
+
+  return recordedTypeByDate;
+};

--- a/src/components/features/calendar/utils/getRecordedTypeByDate.ts
+++ b/src/components/features/calendar/utils/getRecordedTypeByDate.ts
@@ -10,21 +10,21 @@ const CATEGORY_TO_BLOB_TYPE: Record<string, CalendarDayBlobType> = {
 };
 
 /**
- * 회고 목록을 날짜별 캘린더 아이콘 타입 맵으로 변환
+ * 회고 목록을 날짜별 카테고리 타입 맵으로 변환
  * key는 `yyyy-MM-dd` 형식이며, value는 `CalendarDayBlobType`
  */
-export const getRecordedTypeByDate = (
+export const getCategoryTypeByDate = (
   data: ReflectionCategoryItem[],
 ): Map<string, CalendarDayBlobType> => {
-  const recordedTypeByDate = new Map<string, CalendarDayBlobType>();
+  const categoryTypeByDate = new Map<string, CalendarDayBlobType>();
 
   for (const { category, createdAt } of data) {
     const type = CATEGORY_TO_BLOB_TYPE[category];
     if (!type) continue;
 
     const dateKey = createdAt.slice(0, 10);
-    recordedTypeByDate.set(dateKey, type);
+    categoryTypeByDate.set(dateKey, type);
   }
 
-  return recordedTypeByDate;
+  return categoryTypeByDate;
 };

--- a/src/components/features/calendar/utils/mapReflectionItems.ts
+++ b/src/components/features/calendar/utils/mapReflectionItems.ts
@@ -1,0 +1,22 @@
+interface MonthReflectionItem {
+  question: {
+    category: string;
+    createdAt: string;
+  };
+}
+
+export interface ReflectionCategoryItem {
+  category: string;
+  createdAt: string;
+}
+
+/**
+ * 내 회고 전체 조회 응답에서 캘린더 계산에 필요한 필드만 추출
+ */
+export const mapReflectionItems = (
+  data: MonthReflectionItem[],
+): ReflectionCategoryItem[] =>
+  data.map(({ question: { category, createdAt } }) => ({
+    category,
+    createdAt,
+  }));

--- a/src/components/features/reflection/constants/queryKeys.ts
+++ b/src/components/features/reflection/constants/queryKeys.ts
@@ -2,4 +2,6 @@ export const reflectionKeys = {
   all: ['reflection'] as const,
   todayQuestion: () => [...reflectionKeys.all, 'todayQuestion'] as const,
   submitReflection: () => [...reflectionKeys.all, 'submitReflection'] as const,
+  monthReflection: (month: string) =>
+    [...reflectionKeys.all, 'monthReflection', month] as const,
 };

--- a/src/components/features/reflection/constants/queryKeys.ts
+++ b/src/components/features/reflection/constants/queryKeys.ts
@@ -4,4 +4,5 @@ export const reflectionKeys = {
   submitReflection: () => [...reflectionKeys.all, 'submitReflection'] as const,
   monthReflection: (month: string) =>
     [...reflectionKeys.all, 'monthReflection', month] as const,
+  todayReflection: () => [...reflectionKeys.all, 'todayReflection'] as const,
 };

--- a/src/components/features/reflection/constants/url.ts
+++ b/src/components/features/reflection/constants/url.ts
@@ -1,4 +1,5 @@
 export const REFLECTION_ENDPOINTS = {
   todayQuestion: '/reflections/today/question',
   submitReflection: '/reflections',
+  monthReflection: '/reflections/me',
 } as const;

--- a/src/components/features/reflection/constants/url.ts
+++ b/src/components/features/reflection/constants/url.ts
@@ -2,4 +2,5 @@ export const REFLECTION_ENDPOINTS = {
   todayQuestion: '/reflections/today/question',
   submitReflection: '/reflections',
   monthReflection: '/reflections/me',
+  todayReflection: '/reflections/today',
 } as const;

--- a/src/components/features/reflection/queries/useMonthReflection.ts
+++ b/src/components/features/reflection/queries/useMonthReflection.ts
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { get } from '@/src/lib/api';
+
+import { reflectionKeys } from '../constants/queryKeys';
+import { REFLECTION_ENDPOINTS } from '../constants/url';
+
+const monthReflectionRequestSchema = z.object({
+  month: z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/), // 2026-02 형태
+});
+
+const monthReflectionItemSchema = z.object({
+  id: z.number(),
+  question: z.object({
+    id: z.number(),
+    sequence: z.number(),
+    category: z.string(),
+    content: z.string(),
+    createdBy: z.string(),
+    createdAt: z.string(),
+  }),
+  content: z.string(),
+  reflectedAt: z.string(),
+});
+
+const monthReflectionResponseSchema = z.array(monthReflectionItemSchema);
+
+export type GetMonthReflectionRequest = z.infer<
+  typeof monthReflectionRequestSchema
+>;
+type YearMonth = GetMonthReflectionRequest['month'];
+
+type GetMonthReflectionResponse = z.infer<typeof monthReflectionResponseSchema>;
+
+const getMonthReflection = async (
+  month: YearMonth,
+): Promise<GetMonthReflectionResponse> => {
+  return get<GetMonthReflectionResponse, GetMonthReflectionRequest>(
+    REFLECTION_ENDPOINTS.monthReflection,
+    {
+      params: { month },
+      paramsSchema: monthReflectionRequestSchema,
+      responseSchema: monthReflectionResponseSchema,
+    },
+  );
+};
+
+export const useMonthReflection = ({ month }: GetMonthReflectionRequest) =>
+  useQuery({
+    queryKey: reflectionKeys.monthReflection(month),
+    queryFn: () => getMonthReflection(month),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });

--- a/src/components/features/reflection/queries/useMonthReflectionQuery.ts
+++ b/src/components/features/reflection/queries/useMonthReflectionQuery.ts
@@ -46,7 +46,7 @@ const getMonthReflection = async (
   );
 };
 
-export const useMonthReflection = ({ month }: GetMonthReflectionRequest) =>
+export const useMonthReflectionQuery = ({ month }: GetMonthReflectionRequest) =>
   useQuery({
     queryKey: reflectionKeys.monthReflection(month),
     queryFn: () => getMonthReflection(month),

--- a/src/components/features/reflection/queries/useMonthReflectionQuery.ts
+++ b/src/components/features/reflection/queries/useMonthReflectionQuery.ts
@@ -31,7 +31,9 @@ export type GetMonthReflectionRequest = z.infer<
 >;
 type YearMonth = GetMonthReflectionRequest['month'];
 
-type GetMonthReflectionResponse = z.infer<typeof monthReflectionResponseSchema>;
+export type GetMonthReflectionResponse = z.infer<
+  typeof monthReflectionResponseSchema
+>;
 
 const getMonthReflection = async (
   month: YearMonth,

--- a/src/components/features/reflection/queries/useTodayReflectionQuery.ts
+++ b/src/components/features/reflection/queries/useTodayReflectionQuery.ts
@@ -34,7 +34,7 @@ const todayReflectionSchema = z.object({
   reflectedAt: z.string(),
 });
 
-type GetTodayReflectionResponse = z.infer<typeof todayReflectionSchema>;
+export type GetTodayReflectionResponse = z.infer<typeof todayReflectionSchema>;
 
 const getTodayReflection = async (): Promise<GetTodayReflectionResponse> => {
   return get<GetTodayReflectionResponse>(REFLECTION_ENDPOINTS.todayReflection, {

--- a/src/components/features/reflection/queries/useTodayReflectionQuery.ts
+++ b/src/components/features/reflection/queries/useTodayReflectionQuery.ts
@@ -23,14 +23,16 @@ const todayReflectionSchema = z.object({
     createdAt: z.string(),
   }),
   content: z.string(),
-  feedback: z.object({
-    id: z.number(),
-    reflectionId: z.number(),
-    score: z.number(),
-    content: z.string().nullable(),
-    status: z.enum(['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED']),
-    createdAt: z.string(),
-  }),
+  feedback: z
+    .object({
+      id: z.number(),
+      reflectionId: z.number(),
+      score: z.number(),
+      content: z.string().nullable(),
+      status: z.enum(['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED']),
+      createdAt: z.string(),
+    })
+    .nullable(),
   reflectedAt: z.string(),
 });
 

--- a/src/components/features/reflection/queries/useTodayReflectionQuery.ts
+++ b/src/components/features/reflection/queries/useTodayReflectionQuery.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { get } from '@/src/lib/api';
+
+import { reflectionKeys } from '../constants/queryKeys';
+import { REFLECTION_ENDPOINTS } from '../constants/url';
+
+const todayReflectionSchema = z.object({
+  id: z.number(),
+  question: z.object({
+    id: z.number(),
+    sequence: z.number(),
+    category: z.enum([
+      'PAST_NEGATIVE',
+      'PAST_POSITIVE',
+      'PRESENT_HEDONISTIC',
+      'PRESENT_FATALISTIC',
+      'FUTURE',
+    ]),
+    content: z.string(),
+    createdBy: z.string(),
+    createdAt: z.string(),
+  }),
+  content: z.string(),
+  feedback: z.object({
+    id: z.number(),
+    reflectionId: z.number(),
+    score: z.number(),
+    content: z.string().nullable(),
+    status: z.enum(['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED']),
+    createdAt: z.string(),
+  }),
+  reflectedAt: z.string(),
+});
+
+type GetTodayReflectionResponse = z.infer<typeof todayReflectionSchema>;
+
+const getTodayReflection = async (): Promise<GetTodayReflectionResponse> => {
+  return get<GetTodayReflectionResponse>(REFLECTION_ENDPOINTS.todayReflection, {
+    responseSchema: todayReflectionSchema,
+  });
+};
+
+export const useTodayReflectionQuery = () =>
+  useQuery({
+    queryKey: reflectionKeys.todayReflection(),
+    queryFn: getTodayReflection,
+  });

--- a/src/components/features/users/constants/queryKeys.ts
+++ b/src/components/features/users/constants/queryKeys.ts
@@ -1,0 +1,4 @@
+export const userKeys = {
+  all: ['users'] as const,
+  detail: () => [...userKeys.all, 'detail'] as const,
+};

--- a/src/components/features/users/constants/url.ts
+++ b/src/components/features/users/constants/url.ts
@@ -1,0 +1,3 @@
+export const USER_ENDPOINTS = {
+  detail: 'users/me',
+} as const;

--- a/src/components/features/users/queries/useUserDetailQuery.ts
+++ b/src/components/features/users/queries/useUserDetailQuery.ts
@@ -15,7 +15,7 @@ const userDetailSchema = z.object({
   createdAt: z.string(),
 });
 
-type UserDetailResponse = z.infer<typeof userDetailSchema>;
+export type UserDetailResponse = z.infer<typeof userDetailSchema>;
 
 const getUserDetail = async (): Promise<UserDetailResponse> => {
   return get<UserDetailResponse>(USER_ENDPOINTS.detail, {

--- a/src/components/features/users/queries/useUserDetailQuery.ts
+++ b/src/components/features/users/queries/useUserDetailQuery.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { get } from '@/src/lib/api';
+
+import { userKeys } from '../constants/queryKeys';
+import { USER_ENDPOINTS } from '../constants/url';
+
+const userDetailSchema = z.object({
+  id: z.number(),
+  email: z.email(),
+  name: z.string(),
+  streakDays: z.number(),
+  isOnboarded: z.boolean(),
+  createdAt: z.string(),
+});
+
+type UserDetailResponse = z.infer<typeof userDetailSchema>;
+
+const getUserDetail = async (): Promise<UserDetailResponse> => {
+  return get<UserDetailResponse>(USER_ENDPOINTS.detail, {
+    responseSchema: userDetailSchema,
+  });
+};
+
+export const useUserDetailQuery = () =>
+  useQuery({
+    queryKey: userKeys.detail(),
+    queryFn: getUserDetail,
+  });

--- a/src/components/ui/ErrorState/ErrorState.tsx
+++ b/src/components/ui/ErrorState/ErrorState.tsx
@@ -9,6 +9,8 @@ interface ErrorStateProps {
   retryLabel?: string;
   onRetry?: () => void;
   className?: HTMLDivElement['className'];
+  titleClassName?: HTMLParagraphElement['className'];
+  descriptionClassName?: HTMLParagraphElement['className'];
 }
 
 const ErrorState = ({
@@ -17,6 +19,8 @@ const ErrorState = ({
   retryLabel = '다시 시도',
   onRetry,
   className,
+  titleClassName,
+  descriptionClassName,
 }: ErrorStateProps) => {
   return (
     <div
@@ -25,9 +29,16 @@ const ErrorState = ({
         className,
       )}
     >
-      <p className="text-heading-h4 text-g-0">{title}</p>
+      <p className={cn('text-heading-h4', titleClassName)}>{title}</p>
       {description && (
-        <p className="text-caption-n text-g-30 opacity-70">{description}</p>
+        <p
+          className={cn(
+            'text-caption-n text-g-30 opacity-70',
+            descriptionClassName,
+          )}
+        >
+          {description}
+        </p>
       )}
       {onRetry && (
         <BottomCTA>

--- a/src/components/ui/Icon/allIcons.ts
+++ b/src/components/ui/Icon/allIcons.ts
@@ -1,6 +1,13 @@
 const allIcons = {
   chevronLeft: '/icons/chevron-left.svg',
   fire: '/icons/fire.svg',
+  calendarDayPastN: '/icons/calendar-day-past-n.svg',
+  calendarDayPastP: '/icons/calendar-day-past-p.svg',
+  calendarDayPresentH: '/icons/calendar-day-present-h.svg',
+  calendarDayPresentF: '/icons/calendar-day-present-f.svg',
+  calendarDayFuture: '/icons/calendar-day-future.svg',
+  calendarDaySlate: '/icons/calendar-day-slate.svg',
+  calendarDayOutline: '/icons/calendar-day-outline.svg',
 } as const;
 
 export default allIcons;

--- a/src/components/ui/Icon/allIcons.ts
+++ b/src/components/ui/Icon/allIcons.ts
@@ -1,5 +1,6 @@
 const allIcons = {
   chevronLeft: '/icons/chevron-left.svg',
+  fire: '/icons/fire.svg',
 } as const;
 
 export default allIcons;


### PR DESCRIPTION
## What is this PR? :mag:
캘린더 페이지를 구현했습니다.

## Changes :memo:
- `app/calendar/page.tsx` 추가 및 캘린더 화면 구성
- 라이브러리 캘린더를 그대로 쓰기보다 커스텀 요구사항 대응이 더 쉬울 것 같아 UI는 직접 구현. 대신 날짜 계산은 직접 구현 비용을 줄이기 위해 `date-fns`를 사용했습니다.
- 캘린더 UI 컴포넌트 추가
- `date-fns`를 이용해 월 이동, 6주(42칸) 그리드, 선택 날짜 초기화 등 캘린더 상태 계산 로직을 구현
- API 연동 쿼리 추가: 
  - 처음에는 `calendar` 폴더에 API 요청 함수를 둘지 고민했지만, 기능 책임 기준으로 배치하는 게 더 적절하다고 판단해 아래처럼 분리했습니다.
  - `useMonthReflectionQuery`: `src/components/features/reflection/queries`
  - `useTodayReflectionQuery`: `src/components/features/reflection/queries`
  - `useUserDetailQuery`: `src/components/features/users/queries`
- 캘린더 관련 아이콘 리소스 추가
- 로딩/에러 처리 정리
  - 섹션 로딩은 `Skeleton` 사용
  - 페이지 상위에서 에러 통일 처리 (`isAnyError`)

---
❗️울퉁불퉁한 원을 벡터로 직접 구현하는 데 한계가 있어 현재는 SVG 아이콘 방식으로 처리했습니다. 테두리는 같은 도형을 뒤에 배치하고 `scale`을 키우는 방식으로 구현했습니다. 추후 디자이너분들이 최종 벡터이미지를 전달해주시면 해당 리소스로 교체할 예정입니다.
❗️summary card 부분도 디자인 디테일 하게 나오면 교체할 예정입니다.
❓회고 상세 페이지로 이동을 구현하려고 하는데, 연결할 화면 라우트 주소를 알려주시면 해당 경로로 연결해두겠습니다.


## Related Issues :link:
Closes #54 

## Screenshot :camera:

https://github.com/user-attachments/assets/85d0118b-2db4-4e12-bc38-89f78fd691c2


---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a calendar feature with monthly view and day-by-day reflection tracking.
  * Added month navigation to browse different time periods.
  * Implemented visual indicators for reflection categories and states across calendar days.
  * Added a streak counter displaying consecutive active days.
  * Included today's reflection summary for quick reference.

* **Dependencies**
  * Added date-fns library for calendar date utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->