### PR TITLE
[Chore] 임시로 production에서도 test-auth 로그인 가능하게 수정

### DIFF
--- a/app/test-auth/page.tsx
+++ b/app/test-auth/page.tsx
@@ -1,7 +1,11 @@
 import { notFound } from 'next/navigation';
 
+import { isTestAuthEnabled } from '@/src/components/features/testAuth/util/guards';
+
 const TestAuthPage = async () => {
-  if (process.env.NODE_ENV !== 'development') {
+  // Original code (복구용)
+  // if (process.env.NODE_ENV !== 'development') {
+  if (!isTestAuthEnabled()) {
     notFound();
   }
 

--- a/src/components/features/testAuth/util/guards.ts
+++ b/src/components/features/testAuth/util/guards.ts
@@ -1,5 +1,21 @@
+// TEMP: 프로덕션에서도 test-auth를 임시 허용합니다.
+// 복구 방법: 이 상수를 삭제하고 아래 주석 처리된 원래 조건을 되살리면 됩니다.
+const TEMP_ALLOW_TEST_AUTH_IN_PRODUCTION = true;
+
+export const isTestAuthEnabled = () => {
+  // Original code (복구용)
+  // return process.env.NODE_ENV === 'development';
+  return (
+    process.env.NODE_ENV === 'development' || TEMP_ALLOW_TEST_AUTH_IN_PRODUCTION
+  );
+};
+
 export const ensureDevelopment = () => {
-  if (process.env.NODE_ENV !== 'development') {
+  // Original code (복구용)
+  // if (process.env.NODE_ENV !== 'development') {
+  //   throw new Error('Test auth API is only available in development.');
+  // }
+  if (!isTestAuthEnabled()) {
     throw new Error('Test auth API is only available in development.');
   }
 };


### PR DESCRIPTION
## What is this PR? :mag:
임시로 production에서도 test-auth 로그인 가능하게 수정

## Changes :memo:
- 임시로 production에서도 test-auth 로그인 가능하게 수정
- 나중에 제거 필요

## Related Issues :link:

## Screenshot :camera:

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated test authentication access control to use a runtime feature guard system, enabling more flexible management of test authentication availability across different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->