### PR TITLE
[Fix] ztpi test에서 y축으로 넘치는 요소가 삭제되는 현상 방지

### DIFF
--- a/src/components/features/test/InProgress/InProgressContent.tsx
+++ b/src/components/features/test/InProgress/InProgressContent.tsx
@@ -46,7 +46,7 @@ const InProgressContent = ({
   const backgroundCardCount = Math.min(remainQuestion, 2);
 
   return (
-    <section className="relative w-full overflow-hidden">
+    <section className="relative w-full overflow-x-clip">
       <AnimatePresence mode="wait" custom={direction}>
         <motion.div
           key={step}


### PR DESCRIPTION
## What is this PR? :mag:

- ztpi test에서 y축으로 넘치는 요소가 삭제되는 현상 방지

## Changes :memo:

- 테스트 화면에서 카드가 옆으로 넘어갈 때 생기는 가로 스크롤을 없애기 위해 overflow-hidden을 넣었으나, y축으로 미리보이는 카드까지 잘려보이는 현상 발생
- overflow-x-clip으로 변경

## Related Issues :link:

## Screenshot :camera:

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved horizontal content clipping behavior in the in-progress section to better manage overflow display while maintaining vertical scrolling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->