### PR TITLE
[Refactor] 캘린더 날짜 선택 요약 카드 연동 및 오늘 회고 404 미작성 처리

### DIFF
--- a/src/components/features/calendar/CalendarMonth/CalendarMonth.tsx
+++ b/src/components/features/calendar/CalendarMonth/CalendarMonth.tsx
@@ -4,6 +4,7 @@ import { format } from 'date-fns';
 import { useMemo } from 'react';
 
 import { useSuspenseMonthReflectionQuery } from '../../reflection/queries/useMonthReflectionQuery';
+import type { SelectedSummaryCardData } from '../CalendarPageClient/CalendarPageClient';
 import { CALENDAR_DATE_FORMAT } from '../constants/calendar';
 import type { UseCalendarStateResult } from '../hooks/useCalendarState';
 import { getCategoryTypeByDate } from '../utils/getCategoryTypeByDate';
@@ -11,12 +12,6 @@ import { mapReflectionItems } from '../utils/mapReflectionItems';
 import CalendarMonthGrid from './CalendarMonthGrid/CalendarMonthGrid';
 import CalendarMonthHeader from './CalendarMonthHeader/CalendarMonthHeader';
 import CalendarMonthWeekdays from './CalendarMonthWeekdays/CalendarMonthWeekdays';
-
-interface SelectedSummaryCardData {
-  questionText: string;
-  reflectionText: string;
-  reflectionId: number | null;
-}
 
 interface CalendarMonthPropsWithSummary extends UseCalendarStateResult {
   onSelectSummary: (summary: SelectedSummaryCardData) => void;

--- a/src/components/features/calendar/CalendarMonth/CalendarMonthGrid/CalendarMonthGrid.tsx
+++ b/src/components/features/calendar/CalendarMonth/CalendarMonthGrid/CalendarMonthGrid.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-
 import {
   type CalendarDayCellType,
   getCalendarDayCells,
@@ -16,6 +14,7 @@ interface CalendarMonthGridProps {
   today: Date;
   categoryTypeByDate: Map<string, CalendarDayRecordByDateItem>;
   selectDate: (date: Date) => void;
+  onSelectSummary: (date: Date) => void;
 }
 
 const CalendarMonthGrid = ({
@@ -25,9 +24,8 @@ const CalendarMonthGrid = ({
   today,
   categoryTypeByDate,
   selectDate,
+  onSelectSummary,
 }: CalendarMonthGridProps) => {
-  const router = useRouter();
-
   const dayCells: CalendarDayCellType[] = getCalendarDayCells({
     days,
     currentMonth,
@@ -36,11 +34,9 @@ const CalendarMonthGrid = ({
     categoryTypeByDate,
   });
 
-  const handleDateSelect = (date: Date, reflectionId?: number) => {
+  const handleDateSelect = (date: Date) => {
     selectDate(date);
-
-    if (reflectionId === undefined) return;
-    router.push(`/reflection/${reflectionId}`);
+    onSelectSummary(date);
   };
 
   return (
@@ -55,9 +51,7 @@ const CalendarMonthGrid = ({
                 isFuture={dayCell.isFuture}
                 hasRecord={dayCell.cellProps.hasRecord}
                 isOutlined={dayCell.cellProps.isOutlined}
-                onClick={() =>
-                  handleDateSelect(dayCell.date, dayCell.reflectionId)
-                }
+                onClick={() => handleDateSelect(dayCell.date)}
               />
             ) : (
               <span aria-hidden className="h-10 w-10" />

--- a/src/components/features/calendar/CalendarPageClient/CalendarPageClient.tsx
+++ b/src/components/features/calendar/CalendarPageClient/CalendarPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
 
 import CalendarMonth from '@/src/components/features/calendar/CalendarMonth/CalendarMonth';
 import CalendarPageFallback from '@/src/components/features/calendar/CalendarPageFallback/CalendarPageFallback';
@@ -10,8 +10,16 @@ import SummaryCard from '@/src/components/features/calendar/SummaryCard/SummaryC
 import BottomNavBar from '@/src/components/layout/BottomNavBar/BottomNavBar';
 import PageHeader from '@/src/components/layout/PageHeader/PageHeader';
 
+interface SelectedSummaryCardData {
+  questionText: string;
+  reflectionText: string;
+  reflectionId: number | null;
+}
+
 const CalendarPageClient = () => {
   const calendarState = useCalendarState();
+  const [selectedSummary, setSelectedSummary] =
+    useState<SelectedSummaryCardData | null>(null);
 
   return (
     <div className="space-y-5 pb-28">
@@ -24,8 +32,11 @@ const CalendarPageClient = () => {
         }
       >
         <StreakBanner />
-        <CalendarMonth {...calendarState} />
-        <SummaryCard />
+        <CalendarMonth
+          {...calendarState}
+          onSelectSummary={setSelectedSummary}
+        />
+        <SummaryCard selectedSummary={selectedSummary} />
       </Suspense>
       {/* TODO: 바뀐 디자인 반영 확인 해야 함 */}
       <BottomNavBar />

--- a/src/components/features/calendar/CalendarPageClient/CalendarPageClient.tsx
+++ b/src/components/features/calendar/CalendarPageClient/CalendarPageClient.tsx
@@ -10,7 +10,7 @@ import SummaryCard from '@/src/components/features/calendar/SummaryCard/SummaryC
 import BottomNavBar from '@/src/components/layout/BottomNavBar/BottomNavBar';
 import PageHeader from '@/src/components/layout/PageHeader/PageHeader';
 
-interface SelectedSummaryCardData {
+export interface SelectedSummaryCardData {
   questionText: string;
   reflectionText: string;
   reflectionId: number | null;

--- a/src/components/features/calendar/SummaryCard/SummaryCard.tsx
+++ b/src/components/features/calendar/SummaryCard/SummaryCard.tsx
@@ -6,12 +6,7 @@ import Card from '@/src/components/ui/Card/Card';
 import Icon from '@/src/components/ui/Icon/Icon';
 
 import { useSuspenseTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
-
-interface SelectedSummaryCardData {
-  questionText: string;
-  reflectionText: string;
-  reflectionId: number | null;
-}
+import type { SelectedSummaryCardData } from '../CalendarPageClient/CalendarPageClient';
 
 interface SummaryCardProps {
   selectedSummary: SelectedSummaryCardData | null;

--- a/src/components/features/calendar/SummaryCard/SummaryCard.tsx
+++ b/src/components/features/calendar/SummaryCard/SummaryCard.tsx
@@ -7,13 +7,32 @@ import Icon from '@/src/components/ui/Icon/Icon';
 
 import { useSuspenseTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
 
-const SummaryCard = () => {
+interface SelectedSummaryCardData {
+  questionText: string;
+  reflectionText: string;
+  reflectionId: number | null;
+}
+
+interface SummaryCardProps {
+  selectedSummary: SelectedSummaryCardData | null;
+}
+
+const SummaryCard = ({ selectedSummary }: SummaryCardProps) => {
   const router = useRouter();
   const { data } = useSuspenseTodayReflectionQuery();
-  const hasReflectionContent = data.content !== null;
+  const hasSelectedDate = selectedSummary !== null;
+  const selectedReflectionId = selectedSummary?.reflectionId ?? null;
+  const hasSelectedReflection = selectedReflectionId !== null;
+  const hasTodayReflectionContent = data.content !== null;
 
   const handleCardClick = () => {
-    if (!hasReflectionContent) {
+    if (hasSelectedDate) {
+      if (!hasSelectedReflection) return;
+      router.push(`/reflection/${selectedReflectionId}`);
+      return;
+    }
+
+    if (!hasTodayReflectionContent) {
       router.push('/reflection');
       return;
     }
@@ -21,24 +40,32 @@ const SummaryCard = () => {
     router.push(`/reflection/${data.id}`);
   };
 
-  const todayQuestion = data.question.content ?? '오늘의 질문이 없습니다.';
-  const todayReflection = data.content ?? '아직 답변하지 않았어요!';
+  const questionText = hasSelectedDate
+    ? (selectedSummary?.questionText ?? '회고를 기록하지 않았어요')
+    : (data.question.content ?? '오늘의 질문이 없습니다.');
+  const reflectionText = hasSelectedDate
+    ? (selectedSummary?.reflectionText ??
+      '다른 날짜를 선택해 회고를 확인해 보세요.')
+    : (data.content ?? '아직 답변하지 않았어요!');
+  const isCardClickable = hasSelectedDate ? hasSelectedReflection : true;
+  const ariaLabel = '오늘 질문 상세 보기';
 
   return (
     <Card className="rounded-2xl bg-g-500 p-5">
       <button
         type="button"
         onClick={handleCardClick}
-        aria-label="오늘 질문 상세 보기"
+        aria-label={ariaLabel}
         className="w-full"
+        disabled={!isCardClickable}
       >
         <div className="flex items-start justify-between gap-4">
-          <p className="text-left font-body-m text-g-0">{todayQuestion}</p>
+          <p className="text-left font-body-m text-g-0">{questionText}</p>
           <Icon name="chevronLeft" size={24} className="pt-1 rotate-180" />
         </div>
       </button>
       <p className="pt-4 line-clamp-2 font-body-s text-g-80">
-        {todayReflection}
+        {reflectionText}
       </p>
     </Card>
   );

--- a/src/components/features/calendar/SummaryCard/SummaryCard.tsx
+++ b/src/components/features/calendar/SummaryCard/SummaryCard.tsx
@@ -43,14 +43,13 @@ const SummaryCard = ({ selectedSummary }: SummaryCardProps) => {
       '다른 날짜를 선택해 회고를 확인해 보세요.')
     : (data?.content ?? '아직 답변하지 않았어요!');
   const isCardClickable = hasSelectedDate ? hasSelectedReflection : true;
-  const ariaLabel = '오늘 질문 상세 보기';
 
   return (
     <Card className="rounded-2xl bg-g-500 p-5">
       <button
         type="button"
         onClick={handleCardClick}
-        aria-label={ariaLabel}
+        aria-label="회고 상세로 이동"
         className="w-full"
         disabled={!isCardClickable}
       >

--- a/src/components/features/calendar/SummaryCard/SummaryCard.tsx
+++ b/src/components/features/calendar/SummaryCard/SummaryCard.tsx
@@ -23,7 +23,7 @@ const SummaryCard = ({ selectedSummary }: SummaryCardProps) => {
   const hasSelectedDate = selectedSummary !== null;
   const selectedReflectionId = selectedSummary?.reflectionId ?? null;
   const hasSelectedReflection = selectedReflectionId !== null;
-  const hasTodayReflectionContent = data.content !== null;
+  const hasTodayReflectionContent = data?.content !== null && data !== null;
 
   const handleCardClick = () => {
     if (hasSelectedDate) {
@@ -37,16 +37,21 @@ const SummaryCard = ({ selectedSummary }: SummaryCardProps) => {
       return;
     }
 
+    if (!data) {
+      router.push('/reflection');
+      return;
+    }
+
     router.push(`/reflection/${data.id}`);
   };
 
   const questionText = hasSelectedDate
     ? (selectedSummary?.questionText ?? '회고를 기록하지 않았어요')
-    : (data.question.content ?? '오늘의 질문이 없습니다.');
+    : (data?.question.content ?? '오늘의 질문이 없습니다.');
   const reflectionText = hasSelectedDate
     ? (selectedSummary?.reflectionText ??
       '다른 날짜를 선택해 회고를 확인해 보세요.')
-    : (data.content ?? '아직 답변하지 않았어요!');
+    : (data?.content ?? '아직 답변하지 않았어요!');
   const isCardClickable = hasSelectedDate ? hasSelectedReflection : true;
   const ariaLabel = '오늘 질문 상세 보기';
 

--- a/src/components/features/calendar/SummaryCard/SummaryCard.tsx
+++ b/src/components/features/calendar/SummaryCard/SummaryCard.tsx
@@ -18,7 +18,7 @@ const SummaryCard = ({ selectedSummary }: SummaryCardProps) => {
   const hasSelectedDate = selectedSummary !== null;
   const selectedReflectionId = selectedSummary?.reflectionId ?? null;
   const hasSelectedReflection = selectedReflectionId !== null;
-  const hasTodayReflectionContent = data?.content !== null && data !== null;
+  const hasTodayReflectionContent = data?.content != null;
 
   const handleCardClick = () => {
     if (hasSelectedDate) {
@@ -28,11 +28,6 @@ const SummaryCard = ({ selectedSummary }: SummaryCardProps) => {
     }
 
     if (!hasTodayReflectionContent) {
-      router.push('/reflection');
-      return;
-    }
-
-    if (!data) {
       router.push('/reflection');
       return;
     }

--- a/src/components/features/home/HomeActionsSection/HomeActionsSection.tsx
+++ b/src/components/features/home/HomeActionsSection/HomeActionsSection.tsx
@@ -17,7 +17,8 @@ const HomeActionsSection = () => {
   const { data: todayReflection, isPending: isTodayReflectionPending } =
     useTodayReflectionQuery();
   const todayReflectionId = todayReflection?.id;
-  const hasTodayReflection = (todayReflectionId ?? 0) > 0;
+  const hasTodayReflection =
+    todayReflection !== null && todayReflection?.content !== null;
 
   const {
     mutate: changeTodayQuestion,

--- a/src/components/features/home/HomeActionsSection/HomeActionsSection.tsx
+++ b/src/components/features/home/HomeActionsSection/HomeActionsSection.tsx
@@ -18,7 +18,7 @@ const HomeActionsSection = () => {
     useTodayReflectionQuery();
   const todayReflectionId = todayReflection?.id;
   const hasTodayReflection =
-    todayReflection !== null && todayReflection?.content !== null;
+    todayReflection != null && todayReflection.content != null;
 
   const {
     mutate: changeTodayQuestion,

--- a/src/components/features/reflection/queries/useTodayReflectionQuery.ts
+++ b/src/components/features/reflection/queries/useTodayReflectionQuery.ts
@@ -2,6 +2,7 @@ import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { get } from '@/src/lib/api';
+import { isApiError } from '@/src/lib/api/error';
 
 import { reflectionKeys } from '../constants/queryKeys';
 import { REFLECTION_ENDPOINTS } from '../constants/url';
@@ -39,9 +40,20 @@ const todayReflectionSchema = z.object({
 export type GetTodayReflectionResponse = z.infer<typeof todayReflectionSchema>;
 
 const getTodayReflection = async () => {
-  return get<GetTodayReflectionResponse>(REFLECTION_ENDPOINTS.todayReflection, {
-    responseSchema: todayReflectionSchema,
-  });
+  try {
+    return await get<GetTodayReflectionResponse>(
+      REFLECTION_ENDPOINTS.todayReflection,
+      {
+        responseSchema: todayReflectionSchema,
+      },
+    );
+  } catch (error) {
+    if (isApiError(error) && error.status === 404) {
+      return null;
+    }
+
+    throw error;
+  }
 };
 
 export const useTodayReflectionQuery = () =>


### PR DESCRIPTION
## What is this PR? :mag:
- 캘린더에서 날짜 클릭 시 즉시 상세 페이지로 이동하던 흐름을, 요약 카드 표시 후 카드 클릭으로 상세 이동하는 흐름으로 변경했습니다.
- 오늘 회고 조회 API가 404를 반환할 때 이를 에러가 아닌 미작성 상태로 처리하도록 보완했습니다.

## Changes :memo:
### 캘린더 날짜 클릭 동작 변경
  - 즉시 상세 이동 제거, 선택 날짜 요약 카드 갱신으로 변경
  - 요약 카드 클릭 시에만 상세 페이지로 이동하도록 분리
  - 선택 날짜에 회고가 없을 때 회고 질문 영역에 안내 문구 대신 표시 

### today reflection 조회 404 응답을 null(미작성 상태)로 처리
  - 홈/캘린더에서 오늘 회고 존재 여부 판단 로직을 미작성 기준에 맞게 정리

## Related Issues :link:
close #89 

## Screenshot :camera:

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tap/select any calendar date to load and display its reflection summary in the summary card.

* **Bug Fixes**
  * Show a friendly message when a selected date has no reflection.
  * Improved detection of "today" reflections by checking content presence.
  * Gracefully handle missing today reflections from the server (no error shown).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->