### PR TITLE
[Fix] UI 개선으로 사용성 향상

### DIFF
--- a/app/reflection/[reflectionId]/feedback/page.tsx
+++ b/app/reflection/[reflectionId]/feedback/page.tsx
@@ -5,7 +5,7 @@ const FeedbackPage = () => {
   return (
     <>
       <PageHeader title="피드백" />
-      <div className="pt-10">
+      <div className="pt-10 pb-24">
         <FeedbackSection />
       </div>
     </>

--- a/src/components/features/onboarding/Introduction/IntroductionNavigation.tsx
+++ b/src/components/features/onboarding/Introduction/IntroductionNavigation.tsx
@@ -25,11 +25,7 @@ const IntroductionNavigation = ({
   };
 
   return (
-    <Button
-      label={isLastStep ? '시작하기' : '다음'}
-      onClick={handleClick}
-      className="h-10"
-    />
+    <Button label={isLastStep ? '시작하기' : '다음'} onClick={handleClick} />
   );
 };
 

--- a/src/components/features/onboarding/Login/LoginButton.tsx
+++ b/src/components/features/onboarding/Login/LoginButton.tsx
@@ -42,7 +42,7 @@ const LoginButton = ({ provider }: LoginButtonProps) => {
     <Button
       label={config.label}
       className={cn(
-        'flex items-center justify-center gap-2 before:content-[""] before:block before:w-4 before:h-4 before:bg-contain before:bg-no-repeat h-10',
+        'flex items-center justify-center gap-2 before:content-[""] before:block before:w-4 before:h-4 before:bg-contain before:bg-no-repeat',
         config.className,
       )}
       onClick={handleLogin}

--- a/src/components/features/reflection/TextArea/TextArea.tsx
+++ b/src/components/features/reflection/TextArea/TextArea.tsx
@@ -47,7 +47,7 @@ const TextArea = ({
     default: {
       wrapper: 'rounded-lg border border-g-0 border-opacity-60 bg-g-700',
       textarea:
-        'min-h-90 w-full resize-none bg-transparent px-4 mt-4 font-body-s text-g-0 placeholder:text-g-0 placeholder:opacity-60 focus:outline-none disabled:opacity-50',
+        'min-h-90 mt-4 w-full resize-none bg-transparent px-4 font-body-s text-[length:var(--font-size-16)] text-g-0 placeholder:text-g-0 placeholder:opacity-60 focus:outline-none disabled:opacity-50',
       counter: 'flex justify-end px-5 pb-4 font-body-s text-g-0',
     },
   }[variant];

--- a/src/components/features/reflection/TextArea/TextArea.tsx
+++ b/src/components/features/reflection/TextArea/TextArea.tsx
@@ -47,7 +47,7 @@ const TextArea = ({
     default: {
       wrapper: 'rounded-lg border border-g-0 border-opacity-60 bg-g-700',
       textarea:
-        'min-h-90 mt-4 w-full resize-none bg-transparent px-4 font-body-s text-[length:var(--font-size-16)] text-g-0 placeholder:text-g-0 placeholder:opacity-60 focus:outline-none disabled:opacity-50',
+        'min-h-90 mt-4 w-full resize-none bg-transparent px-4 font-body-base text-g-0 placeholder:text-g-0 placeholder:opacity-60 focus:outline-none disabled:opacity-50',
       counter: 'flex justify-end px-5 pb-4 font-body-s text-g-0',
     },
   }[variant];

--- a/src/components/features/reflectionDetail/Header/Header.tsx
+++ b/src/components/features/reflectionDetail/Header/Header.tsx
@@ -14,6 +14,7 @@ const Header = () => {
       title="나의 기록"
       leftIcon={<Icon name="chevronLeft" size={25} />}
       onLeftClick={() => goBackOrHome(router)}
+      className="-mx-7.5 px-5"
     />
   );
 };

--- a/src/components/features/testResult/Result/Result.tsx
+++ b/src/components/features/testResult/Result/Result.tsx
@@ -55,7 +55,7 @@ const Result = ({ testRecordId }: ResultProps) => {
       </article>
 
       <section className="flex flex-col items-center gap-3">
-        <Button label="완료" onClick={goHome} className="h-10 text-g-900" />
+        <Button label="완료" onClick={goHome} className="text-g-900" />
         <Link
           className="text-primary font-caption-n underline underline-offset-4"
           href="/characters"

--- a/src/components/layout/BottomCTA/BottomCTA.tsx
+++ b/src/components/layout/BottomCTA/BottomCTA.tsx
@@ -6,7 +6,7 @@ interface BottomCTAProps {
 
 const BottomCTA = ({ children }: BottomCTAProps) => {
   return (
-    <div className="fixed bottom-0 left-1/2 z-10 w-full max-w-110 -translate-x-1/2 px-7.5 py-4">
+    <div className="fixed bottom-0 left-1/2 z-10 w-full max-w-110 -translate-x-1/2 px-7.5 pt-4 pb-8">
       <div className="flex items-center justify-center">{children}</div>
     </div>
   );

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -74,3 +74,10 @@
   font-weight: var(--font-weight-regular);
   letter-spacing: var(--letter-spacing-tight);
 }
+
+@utility font-body-base {
+  font-size: var(--font-size-16);
+  line-height: var(--line-height-148);
+  font-weight: var(--font-weight-regular);
+  letter-spacing: var(--letter-spacing-tight);
+}


### PR DESCRIPTION
## What is this PR? :mag:
- 모바일 사용성 개선을 위해 회고 입력창 확대 현상을 방지
- 회고 상세페이지 헤더 간격 조정
- 온보딩/테스트 결과 하단 버튼 크기 조정
- 로그인 페이지 버튼 크키 조정

## Changes :memo:
  - 회고 입력 textarea에 16px 폰트 크기를 적용해 모바일 포커스 시 자동 확대가 발생하지 않도록 수정했습니다
  - 회고 상세 페이지 헤더에만 별도 좌우 여백을 적용
  - 온보딩/로그인, 테스트 결과 페이지 버튼에서 `h-10` 오버라이드를 제거해 공용 버튼 기본 높이를 사용하도록 정리했습니다
    - 수정 하다 보니 로그인 페이지 버튼도 조금 더 크게 해도 좋을 것 같아 함께 수정했습니다.
  - 하단 고정 CTA의 bottom spacing을 늘려 버튼이 화면 하단에 너무 붙어 보이지 않도록 조정했습니다

## Related Issues :link:
closes #101 

## Screenshot :camera:
|  회고 상세 페이지 헤더  | 온보딩 하단 버튼 | 로그인 페이지 버튼 |
|--------|--------|--------|
| <img width="410" height="851" alt="image" src="https://github.com/user-attachments/assets/3001f0cc-07b7-4b1e-be1f-342a01292cf8" /> | <img width="457" height="886" alt="스크린샷 2026-03-26 오후 6 16 10" src="https://github.com/user-attachments/assets/a5c62c87-2e68-4a5f-88bc-b021931a265b" /> | <img width="435" height="885" alt="스크린샷 2026-03-26 오후 6 13 42" src="https://github.com/user-attachments/assets/b1b01769-4980-4e20-b6e0-0eff786f294e" /> | 
---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed explicit fixed heights from several buttons so they now use shared/default sizing.
  * Adjusted vertical and horizontal spacing for headers, bottom CTA, and feedback pages for improved layout consistency.
  * Added and applied a new base body font utility to standardize text sizing in inputs and body copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->