### PR TITLE
[Fix] 테스트 결과화면에서 진입 경로에 따른 완료 버튼 동작 분기

### DIFF
--- a/app/ztpi/[ztpiTestId]/page.tsx
+++ b/app/ztpi/[ztpiTestId]/page.tsx
@@ -2,18 +2,21 @@ import Result from '@/src/components/features/testResult/Result/Result';
 import PageHeader from '@/src/components/layout/PageHeader/PageHeader';
 
 interface ZtpiTestResultPageProps {
-  params: Promise<{
-    ztpiTestId: string;
-  }>;
+  params: Promise<{ ztpiTestId: string }>;
+  searchParams: Promise<{ from?: string }>;
 }
 
-const ZtpiTestResultPage = async ({ params }: ZtpiTestResultPageProps) => {
+const ZtpiTestResultPage = async ({
+  params,
+  searchParams,
+}: ZtpiTestResultPageProps) => {
   const { ztpiTestId } = await params;
+  const { from } = await searchParams;
 
   return (
     <>
       <PageHeader title="테스트 결과" />
-      <Result testRecordId={+ztpiTestId} />
+      <Result testRecordId={+ztpiTestId} from={from} />
     </>
   );
 };

--- a/src/components/features/profile/hooks/useTestSectionActions.ts
+++ b/src/components/features/profile/hooks/useTestSectionActions.ts
@@ -45,7 +45,7 @@ export const useTestSectionActions = () => {
       return;
     }
 
-    router.push(`/ztpi/${latestRecord.id}`);
+    router.push(`/ztpi/${latestRecord.id}?from=profile`);
   };
 
   return {

--- a/src/components/features/test/ViewResultButton/ViewResultButton.tsx
+++ b/src/components/features/test/ViewResultButton/ViewResultButton.tsx
@@ -12,7 +12,7 @@ const ViewResultButton = ({ resultId }: ViewResultButtonProps) => {
   const router = useRouter();
 
   const handleViewResultClick = () => {
-    router.push(`/ztpi/${resultId}`);
+    router.push(`/ztpi/${resultId}?from=test`);
   };
 
   return (

--- a/src/components/features/testResult/Result/Result.tsx
+++ b/src/components/features/testResult/Result/Result.tsx
@@ -13,16 +13,21 @@ import ScoreGraph from '../ScoreGraph/ScoreGraph';
 
 interface ResultProps {
   testRecordId: number;
+  from?: string;
 }
 
-const Result = ({ testRecordId }: ResultProps) => {
+const Result = ({ testRecordId, from }: ResultProps) => {
   const router = useRouter();
   const { data, isPending, isError, refetch } = useTestRecordQuery({
     testRecordId,
   });
 
-  const goHome = () => {
-    router.push('/');
+  const handleComplete = () => {
+    if (from === 'profile') {
+      router.push('/profile');
+    } else {
+      router.push('/');
+    }
   };
 
   if (isPending) {
@@ -55,7 +60,7 @@ const Result = ({ testRecordId }: ResultProps) => {
       </article>
 
       <section className="flex flex-col items-center gap-3">
-        <Button label="완료" onClick={goHome} className="text-g-900" />
+        <Button label="완료" onClick={handleComplete} className="text-g-900" />
         <Link
           className="text-primary font-caption-n underline underline-offset-4"
           href="/characters"


### PR DESCRIPTION
## What is this PR? :mag:

- 테스트 결과화면에서, 진입 경로에 따른 완료 버튼 동작 분기

## Changes :memo:

테스트 결과 페이지(/ztpi/[id])는 두 가지 경로로 진입할 수 있었음
```
  a. 테스트 완료 후 "결과 확인하기" 버튼
  b. 마이페이지 "지난 테스트결과 보기" 버튼
```

- 기존에는 완료 버튼이 항상 홈(/)으로 이동했으나, 진입 경로에 따라 목적지를 다르게 처리 (from 파라미터로 구분)
- 테스트 완료 후 결과 확인할 때
   ```tsx
  const handleViewResultClick = () => {
    router.push(`/ztpi/${resultId}?from=test`);
  };
  ```
- 마이페이지에서 지난 결과 확인할 때
  ```tsx
    const handleViewLatestResult = () => {
      // ...
      router.push(`/ztpi/${latestRecord.id}?from=profile`);
    };
  ```

- 테스트 결과 컴포넌트에서 from 에 따라 완료 버튼 동작 분기
```tsx
  const handleComplete = () => {
    if (from === 'profile') {
      router.push('/profile');
    } else {
      router.push('/');
    }
  };
```

## Related Issues :link:

closes #106

## Screenshot :camera:

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced result navigation: Completing a test result now intelligently returns you to your previous location. Access results from your profile to return to profile, or from the test section to return there—instead of always going to the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->