### PR TITLE
[Fix] 아코디언 컴포넌트의 애니메이션이 끊겨보이는 현상 수정

### DIFF
--- a/src/components/features/characters/Accordion/AccordionItem.tsx
+++ b/src/components/features/characters/Accordion/AccordionItem.tsx
@@ -1,4 +1,3 @@
-import { AnimatePresence, motion } from 'motion/react';
 import Image from 'next/image';
 
 import Icon from '@/src/components/ui/Icon/Icon';
@@ -37,13 +36,12 @@ const AccordionItem = ({
   const bgColorClass = BG_COLOR_MAP[color] || 'bg-g-0';
 
   return (
-    <div className="border-b border-g-600 last:border-none rounded-2xl">
+    <div className="border-b border-g-600 last:border-none rounded-2xl overflow-hidden">
       <button
         type="button"
         className={cn(
           'flex w-full items-center justify-between text-left focus:outline-none px-4 py-2',
           bgColorClass,
-          isOpen ? 'rounded-t-2xl' : 'rounded-2xl',
         )}
         onClick={onToggle}
         aria-expanded={isOpen}
@@ -69,15 +67,14 @@ const AccordionItem = ({
           )}
         />
       </button>
-      <AnimatePresence initial={false}>
-        {isOpen && (
-          <motion.div
-            initial={{ opacity: 0, clipPath: 'inset(0 0 100% 0)' }}
-            animate={{ opacity: 1, clipPath: 'inset(0 0 0% 0)' }}
-            exit={{ opacity: 0, clipPath: 'inset(0 0 100% 0)' }}
-            transition={{ duration: 0.25, ease: 'easeInOut' }}
-            className="overflow-hidden space-y-3 bg-g-600 p-4 rounded-b-2xl"
-          >
+      <div
+        className={cn(
+          'grid transition-[grid-template-rows] duration-250 ease-in-out',
+          isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="space-y-3 bg-g-600 p-4 rounded-b-2xl">
             <div className="space-y-1">
               <p className="font-heading-h4 text-g-0">성향</p>
               <p className="text-g-40 font-body-s">{personality}</p>
@@ -90,9 +87,9 @@ const AccordionItem = ({
                 ))}
               </ul>
             </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## What is this PR? :mag:

다른 캐릭터 알아보기 페이지에서 아코디언 컴포넌트의 애니메이션이 끊겨보이는 현상 수정

## Changes :memo:

- Framer Motion height 애니메이션을 CSS Grid 방식으로 교체
- overflow-hidden + rounded-2xl 조합으로 모서리 전환 어색함 제거


## Related Issues :link:

closes #109 

## Screenshot :camera:

https://github.com/user-attachments/assets/07593f74-38db-48ae-bab8-16e9058d2730

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the accordion expand/collapse animation implementation with optimized CSS-based transitions and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->