### PR TITLE
[Fix] 피드백 생성 완료가 확인될 때까지 기다리도록 수정

### DIFF
--- a/src/components/features/reflection/hooks/useReflectionForm.ts
+++ b/src/components/features/reflection/hooks/useReflectionForm.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -5,6 +6,7 @@ import { useCreateReflectionFeedbackMutation } from '@/src/components/features/r
 import { useToast } from '@/src/hooks/useToast';
 import { isApiError } from '@/src/lib/api/error';
 
+import { reflectionKeys } from '../constants/queryKeys';
 import { useSubmitReflectionMutation } from '../queries/useSubmitReflectionMutation';
 
 interface UseReflectionFormResult {
@@ -16,6 +18,7 @@ interface UseReflectionFormResult {
 
 export const useReflectionForm = (): UseReflectionFormResult => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [content, setContent] = useState('');
   const { showToast } = useToast();
 
@@ -33,12 +36,16 @@ export const useReflectionForm = (): UseReflectionFormResult => {
   const createFeedback = async (reflectionId: number): Promise<boolean> => {
     try {
       await requestCreateFeedback({ reflectionId });
+      await queryClient.invalidateQueries({
+        queryKey: reflectionKeys.todayReflection(),
+      });
       return true;
     } catch {
       showToast({
         message: '피드백 생성에 실패했어요. 잠시 후 다시 시도해주세요.',
         variant: 'alert',
       });
+
       return false;
     }
   };

--- a/src/components/features/reflection/queries/useTodayReflectionQuery.ts
+++ b/src/components/features/reflection/queries/useTodayReflectionQuery.ts
@@ -1,4 +1,8 @@
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import {
+  useQuery,
+  type UseQueryOptions,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { get } from '@/src/lib/api';
@@ -39,6 +43,11 @@ const todayReflectionSchema = z.object({
 
 export type GetTodayReflectionResponse = z.infer<typeof todayReflectionSchema>;
 
+type TodayReflectionQueryOptions = Omit<
+  UseQueryOptions<GetTodayReflectionResponse | null>,
+  'queryKey' | 'queryFn'
+>;
+
 const getTodayReflection = async () => {
   try {
     return await get<GetTodayReflectionResponse>(
@@ -56,10 +65,13 @@ const getTodayReflection = async () => {
   }
 };
 
-export const useTodayReflectionQuery = () =>
+export const useTodayReflectionQuery = (
+  options?: TodayReflectionQueryOptions,
+) =>
   useQuery({
     queryKey: reflectionKeys.todayReflection(),
     queryFn: getTodayReflection,
+    ...options,
   });
 
 export const useSuspenseTodayReflectionQuery = () =>

--- a/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
+++ b/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import BottomCTA from '@/src/components/layout/BottomCTA/BottomCTA';
 import Button from '@/src/components/ui/Button/Button';
 import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
-import { type Category } from '@/src/lib/constants/character';
 import { goToHome } from '@/src/lib/helpers/navigation';
 
 import { useTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
@@ -32,17 +31,22 @@ const FeedbackSection = () => {
   });
 
   const feedback = data?.feedback;
+  const category = data?.question?.category;
+  const feedbackContent = feedback?.content;
   const isGenerating =
-    data !== null &&
-    (!feedback ||
-      feedback.status === 'PENDING' ||
-      feedback.status === 'PROCESSING');
-  const hasError = isError || !feedback || feedback.status === 'FAILED';
+    isPending ||
+    !feedback ||
+    feedback.status === 'PENDING' ||
+    feedback.status === 'PROCESSING';
+  const hasCompletedFeedback =
+    feedback?.status === 'COMPLETED' && Boolean(feedbackContent);
+  const hasError =
+    isError ||
+    feedback?.status === 'FAILED' ||
+    !hasCompletedFeedback ||
+    !category;
 
-  const feedbackContent = feedback?.content ?? '';
-  const category = data?.question.category as Category;
-
-  if (isPending || isGenerating) {
+  if (isGenerating) {
     return (
       <>
         <GeneratingFeedbackCard />
@@ -57,7 +61,19 @@ const FeedbackSection = () => {
     return (
       <ErrorState
         title="피드백을 불러오지 못했어요"
-        description="잠시 후 다시 시도해 주세요."
+        description="잠시 후 다시 확인해 주세요."
+        retryLabel="홈으로 돌아가기"
+        onRetry={() => goToHome(router)}
+      />
+    );
+  }
+
+  if (!feedbackContent || !category) {
+    return (
+      <ErrorState
+        title="피드백을 불러오지 못했어요"
+        description="잠시 후 다시 확인해 주세요."
+        retryLabel="홈으로 돌아가기"
         onRetry={() => goToHome(router)}
       />
     );

--- a/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
+++ b/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
@@ -5,12 +5,12 @@ import { useRouter } from 'next/navigation';
 import BottomCTA from '@/src/components/layout/BottomCTA/BottomCTA';
 import Button from '@/src/components/ui/Button/Button';
 import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
-import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
 import { type Category } from '@/src/lib/constants/character';
 import { goToHome } from '@/src/lib/helpers/navigation';
 
 import { useTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
 import CompleteButton from '../CompleteButton/CompleteButton';
+import GeneratingFeedbackCard from '../GeneratingFeedbackCard/GeneratingFeedbackCard';
 import ResultCard from '../ResultCard/ResultCard';
 
 const FeedbackSection = () => {
@@ -45,7 +45,7 @@ const FeedbackSection = () => {
   if (isPending || isGenerating) {
     return (
       <>
-        <Skeleton className="h-117.5 w-full" ariaLabel="피드백 생성 중" />
+        <GeneratingFeedbackCard />
         <BottomCTA>
           <Button label="피드백 생성 중..." disabled />
         </BottomCTA>

--- a/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
+++ b/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 import BottomCTA from '@/src/components/layout/BottomCTA/BottomCTA';
 import Button from '@/src/components/ui/Button/Button';
@@ -12,8 +13,11 @@ import CompleteButton from '../CompleteButton/CompleteButton';
 import GeneratingFeedbackCard from '../GeneratingFeedbackCard/GeneratingFeedbackCard';
 import ResultCard from '../ResultCard/ResultCard';
 
+const FEEDBACK_TIMEOUT_MS = 10000;
+
 const FeedbackSection = () => {
   const router = useRouter();
+  const [isTimedOut, setIsTimedOut] = useState(false);
   const { data, isPending, isError } = useTodayReflectionQuery({
     staleTime: 0,
     refetchOnMount: 'always',
@@ -42,9 +46,24 @@ const FeedbackSection = () => {
     feedback?.status === 'COMPLETED' && Boolean(feedbackContent);
   const hasError =
     isError ||
+    isTimedOut ||
     feedback?.status === 'FAILED' ||
     !hasCompletedFeedback ||
     !category;
+
+  useEffect(() => {
+    if (!isGenerating || isTimedOut) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setIsTimedOut(true);
+    }, FEEDBACK_TIMEOUT_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [isGenerating, isTimedOut]);
 
   if (isGenerating) {
     return (

--- a/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
+++ b/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 
 import BottomCTA from '@/src/components/layout/BottomCTA/BottomCTA';
+import Button from '@/src/components/ui/Button/Button';
 import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
 import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
 import { type Category } from '@/src/lib/constants/character';
@@ -14,20 +15,39 @@ import ResultCard from '../ResultCard/ResultCard';
 
 const FeedbackSection = () => {
   const router = useRouter();
-  const { data, isPending, isError } = useTodayReflectionQuery();
+  const { data, isPending, isError } = useTodayReflectionQuery({
+    staleTime: 0,
+    refetchOnMount: 'always',
+    refetchInterval: (query) => {
+      const reflection = query.state.data;
+      const feedback = reflection?.feedback;
+      const shouldPoll =
+        reflection !== null &&
+        (!feedback ||
+          feedback.status === 'PENDING' ||
+          feedback.status === 'PROCESSING');
+
+      return shouldPoll ? 1000 : false;
+    },
+  });
 
   const feedback = data?.feedback;
+  const isGenerating =
+    data !== null &&
+    (!feedback ||
+      feedback.status === 'PENDING' ||
+      feedback.status === 'PROCESSING');
   const hasError = isError || !feedback || feedback.status === 'FAILED';
 
   const feedbackContent = feedback?.content ?? '';
   const category = data?.question.category as Category;
 
-  if (isPending) {
+  if (isPending || isGenerating) {
     return (
       <>
         <Skeleton className="h-117.5 w-full" ariaLabel="피드백 생성 중" />
         <BottomCTA>
-          <CompleteButton />
+          <Button label="피드백 생성 중..." disabled />
         </BottomCTA>
       </>
     );

--- a/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
+++ b/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
@@ -39,9 +39,10 @@ const FeedbackSection = () => {
   const feedbackContent = feedback?.content;
   const isGenerating =
     isPending ||
-    !feedback ||
-    feedback.status === 'PENDING' ||
-    feedback.status === 'PROCESSING';
+    (data !== null &&
+      (!feedback ||
+        feedback.status === 'PENDING' ||
+        feedback.status === 'PROCESSING'));
   const hasCompletedFeedback =
     feedback?.status === 'COMPLETED' && Boolean(feedbackContent);
   const hasError =

--- a/src/components/features/reflectionFeedback/GeneratingFeedbackCard/GeneratingFeedbackCard.tsx
+++ b/src/components/features/reflectionFeedback/GeneratingFeedbackCard/GeneratingFeedbackCard.tsx
@@ -1,0 +1,30 @@
+import Badge from '@/src/components/ui/Badge/Badge';
+import Card from '@/src/components/ui/Card/Card';
+import Icon from '@/src/components/ui/Icon/Icon';
+import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
+
+const GeneratingFeedbackCard = () => {
+  return (
+    <Card className="flex max-h-117.5 flex-col items-center justify-center gap-6 bg-g-500 px-8 py-10">
+      <div className="space-y-2 text-center">
+        <p className="font-heading-h3 text-g-0">피드백 생성중</p>
+        <p className="font-body-s text-g-60">
+          오늘 회고를 바탕으로 피드백을 생성하고 있어요.
+        </p>
+        <p className="font-body-s text-g-60">잠시만 기다려주세요.</p>
+      </div>
+
+      <div className="w-full space-y-3">
+        <div className="space-y-3">
+          <Skeleton className="h-4 w-full" ariaLabel="피드백 본문 생성 중" />
+          <Skeleton className="h-4 w-full" ariaLabel="피드백 본문 생성 중" />
+          <Skeleton className="h-4 w-11/12" ariaLabel="피드백 본문 생성 중" />
+          <Skeleton className="h-4 w-full" ariaLabel="피드백 본문 생성 중" />
+          <Skeleton className="h-4 w-4/5" ariaLabel="피드백 본문 생성 중" />
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default GeneratingFeedbackCard;

--- a/src/components/features/reflectionFeedback/GeneratingFeedbackCard/GeneratingFeedbackCard.tsx
+++ b/src/components/features/reflectionFeedback/GeneratingFeedbackCard/GeneratingFeedbackCard.tsx
@@ -1,6 +1,4 @@
-import Badge from '@/src/components/ui/Badge/Badge';
 import Card from '@/src/components/ui/Card/Card';
-import Icon from '@/src/components/ui/Icon/Icon';
 import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
 
 const GeneratingFeedbackCard = () => {


### PR DESCRIPTION
## What is this PR? :mag:
- 회고 피드백 생성 흐름을 개선했습니다.
- 피드백 생성 API 호출 직후 결과 페이지로 이동하되, 결과 페이지에서 생성 중 상태를 polling으로 확인하고, 완료된 경우에만 결과를 렌더하도록 수정했습니다.
- 또 생성이 오래 걸릴 경우 10초 후 에러 상태로 전환되도록 처리했습니다.

## Changes :memo:
- 피드백 결과 페이지에서 `todayReflection`을 재조회하도록 수정
- `PENDING`, `PROCESSING`, `feedback === null` 상태를 생성 중으로 처리
- 피드백 생성 중 스켈레톤 카드 UI 추가
- 피드백이 `COMPLETED`이고 `content`, `category`가 있을 때만 결과 카드 렌더링하도록 보강
- 피드백 생성이 10초 이상 지연되면 에러 화면으로 전환하도록 timeout 처리 추가
- 에러 상태 문구를 `잠시 후 다시 확인해 주세요.`, 버튼을 `홈으로 돌아가기`로 정리

## Related Issues :link:
closes #112

## Screenshot :camera:
피드백 생성을 기다리는 동안에는 아래와 같은 화면이 보여지도록 했습니다.
<img width="400" height="982" alt="image" src="https://github.com/user-attachments/assets/ae34f433-87a0-46c0-ac78-bb143146249b" />


---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "Generating feedback" card showing in-progress placeholders while feedback is created.
  * 10-second timeout visual safeguard during feedback generation.

* **Improvements**
  * Automatic refresh of reflection data after feedback is created.
  * Polling refined to update only while feedback is actively processing.
  * Query options now allow finer control over caching/retry behavior.

* **Bug Fixes**
  * Improved error detection and clearer recovery messaging with retry navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->