### PR TITLE
[Feat] 친구 회고 확인 기능 구현

### DIFF
--- a/app/groups/GroupsPageClient.tsx
+++ b/app/groups/GroupsPageClient.tsx
@@ -4,15 +4,20 @@ import Image from 'next/image';
 import { Suspense, useState } from 'react';
 
 import type { GroupType } from '@/src/components/features/groups/constants/groupType';
+import FriendReflectionPanel from '@/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel';
 import GroupListSection from '@/src/components/features/groups/GroupListSection/GroupListSection';
 import GroupListSkeleton from '@/src/components/features/groups/GroupListSection/GroupListSkeleton';
 import GroupTab from '@/src/components/features/groups/GroupTab/GroupTab';
+import type { GroupFriendItem } from '@/src/components/features/groups/queries/useGroupFriendListQuery';
 import RankingSection from '@/src/components/features/groups/Ranking/RankingSection/RankingSection';
 import PageHeader from '@/src/components/layout/PageHeader/PageHeader';
 
 const GroupsPageClient = () => {
   const [activeTab, setActiveTab] = useState<GroupType>('FRIEND');
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
+  const [selectedFriend, setSelectedFriend] = useState<GroupFriendItem | null>(
+    null,
+  );
 
   const handleTabChange = (tab: GroupType) => {
     setActiveTab(tab);
@@ -39,9 +44,18 @@ const GroupsPageClient = () => {
         </Suspense>
         {selectedGroupId !== null ? (
           <div className="bg-g-500 -mx-7.5 px-7.5 py-6 mt-2 flex-1 min-h-0">
-            <RankingSection groupId={selectedGroupId} activeTab={activeTab} />
+            <RankingSection
+              groupId={selectedGroupId}
+              activeTab={activeTab}
+              onSelect={setSelectedFriend}
+            />
           </div>
         ) : null}
+
+        <FriendReflectionPanel
+          friend={selectedFriend}
+          onClose={() => setSelectedFriend(null)}
+        />
       </div>
     </div>
   );

--- a/app/reflection/[reflectionId]/page.tsx
+++ b/app/reflection/[reflectionId]/page.tsx
@@ -1,4 +1,4 @@
-import Detail from '@/src/components/features/reflectionDetail/Detail/Detail';
+import ReflectionDetailClient from '@/src/components/features/reflectionDetail/Detail/ReflectionDetailClient';
 import Header from '@/src/components/features/reflectionDetail/Header/Header';
 import BottomNavBar from '@/src/components/layout/BottomNavBar/BottomNavBar';
 
@@ -14,7 +14,7 @@ const Page = async ({ params }: PageProps) => {
   return (
     <div className="space-y-10 pb-20">
       <Header />
-      <Detail reflectionId={+reflectionId} />
+      <ReflectionDetailClient reflectionId={+reflectionId} />
       <BottomNavBar />
     </div>
   );

--- a/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel.stories.tsx
+++ b/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import FriendReflectionPanel from './FriendReflectionPanel';
+
+const meta = {
+  title: 'Features/Groups/FriendReflectionPanel',
+  component: FriendReflectionPanel,
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'mobile1' },
+  },
+  tags: ['autodocs'],
+  args: {
+    onClose: () => {},
+  },
+} satisfies Meta<typeof FriendReflectionPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockFriend = {
+  userId: 1,
+  nickname: '지민',
+  questionContent: '오늘 하루 중 가장 기억에 남는 순간은 무엇인가요?',
+  questionCategory: 'PRESENT_HEDONISTIC' as const,
+  answerText:
+    '오늘은 오랜 친구를 만나서 함께 카페에서 이야기를 나눴어요. 별거 아닌 일상 얘기였지만 정말 즐거웠고 많이 웃었습니다.',
+  streakDays: 14,
+  totalDays: 30,
+};
+
+export const Open: Story = {
+  args: {
+    friend: mockFriend,
+  },
+};
+
+export const Closed: Story = {
+  args: {
+    friend: null,
+  },
+};
+
+export const PastPositive: Story = {
+  args: {
+    friend: {
+      ...mockFriend,
+      nickname: '수진',
+      questionCategory: 'PAST_POSITIVE',
+      questionContent: '과거에 가장 행복했던 기억은 무엇인가요?',
+      answerText: '초등학교 때 가족과 함께 바다로 여행을 떠났던 기억이 납니다.',
+    },
+  },
+};
+
+export const Future: Story = {
+  args: {
+    friend: {
+      ...mockFriend,
+      nickname: '현우',
+      questionCategory: 'FUTURE',
+      questionContent: '올해 꼭 이루고 싶은 목표가 있나요?',
+      answerText:
+        '매일 30분씩 운동하는 습관을 만들고 싶어요. 작은 것부터 시작해서 꾸준히 해나가겠습니다.',
+    },
+  },
+};
+
+export const LongAnswer: Story = {
+  args: {
+    friend: {
+      ...mockFriend,
+      nickname: '예린',
+      questionCategory: 'PAST_NEGATIVE',
+      questionContent: '최근에 후회되는 일이 있었나요?',
+      answerText:
+        '친구에게 상처 주는 말을 무심코 했는데 그게 계속 마음에 걸려요. 그때 더 신중하게 말했어야 했는데, 이제는 그 친구가 저를 어떻게 생각할지 걱정됩니다. 앞으로는 말하기 전에 한 번 더 생각하는 습관을 들여야겠다고 다짐했어요.',
+    },
+  },
+};

--- a/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel.stories.tsx
+++ b/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
+import type { GroupFriendItem } from '@/src/components/features/groups/queries/useGroupFriendListQuery';
+
 import FriendReflectionPanel from './FriendReflectionPanel';
 
 const meta = {
@@ -18,11 +20,12 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const mockFriend = {
+const mockFriend: GroupFriendItem = {
   userId: 1,
   nickname: '지민',
   questionContent: '오늘 하루 중 가장 기억에 남는 순간은 무엇인가요?',
-  questionCategory: 'PRESENT_HEDONISTIC' as const,
+  questionCategory: 'PRESENT_HEDONISTIC',
+  userCategory: 'PRESENT_HEDONISTIC',
   answerText:
     '오늘은 오랜 친구를 만나서 함께 카페에서 이야기를 나눴어요. 별거 아닌 일상 얘기였지만 정말 즐거웠고 많이 웃었습니다.',
   streakDays: 14,

--- a/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel.tsx
+++ b/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+
+import Detail from '@/src/components/features/reflectionDetail/Detail/Detail';
+import PageHeader from '@/src/components/layout/PageHeader/PageHeader';
+import Icon from '@/src/components/ui/Icon/Icon';
+import { cn } from '@/src/lib/helpers/cn';
+
+import type { GroupFriendItem } from '../queries/useGroupFriendListQuery';
+
+interface FriendReflectionPanelProps {
+  friend: GroupFriendItem | null;
+  onClose: () => void;
+}
+
+const FriendReflectionPanel = ({
+  friend,
+  onClose,
+}: FriendReflectionPanelProps) => {
+  const isOpen = friend !== null;
+  const [displayFriend, setDisplayFriend] = useState<GroupFriendItem | null>(
+    friend,
+  );
+  const [prevFriend, setPrevFriend] = useState(friend);
+
+  if (prevFriend !== friend) {
+    setPrevFriend(friend);
+    if (friend !== null) setDisplayFriend(friend);
+  }
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-50 bg-g-700 transition-transform duration-300',
+        isOpen ? 'translate-x-0' : 'translate-x-full',
+      )}
+    >
+      <div className="max-w-110 mx-auto h-full px-7.5 overflow-y-auto">
+        <div className="space-y-10 pb-20">
+          <PageHeader
+            title="친구 기록"
+            leftIcon={<Icon name="chevronLeft" size={25} />}
+            onLeftClick={onClose}
+            className="-mx-7.5 px-5"
+          />
+
+          {displayFriend && (
+            <Detail
+              questionCategory={displayFriend.questionCategory}
+              questionContent={displayFriend.questionContent}
+              answerContent={displayFriend.answerText}
+              friendNickname={displayFriend.nickname}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FriendReflectionPanel;

--- a/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel.tsx
+++ b/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel.tsx
@@ -51,7 +51,7 @@ const FriendReflectionPanel = ({
       <div className="max-w-110 mx-auto h-full px-7.5 overflow-y-auto">
         <div className="space-y-10 pb-20">
           <PageHeader
-            title="친구 기록"
+            title="친구 회고"
             leftIcon={<Icon name="chevronLeft" size={25} />}
             onLeftClick={onClose}
             className="-mx-7.5 px-5"

--- a/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel.tsx
+++ b/src/components/features/groups/FriendReflectionPanel/FriendReflectionPanel.tsx
@@ -29,6 +29,18 @@ const FriendReflectionPanel = ({
     if (friend !== null) setDisplayFriend(friend);
   }
 
+  const reflectionDetail =
+    displayFriend?.questionCategory &&
+    displayFriend.questionContent &&
+    displayFriend.answerText
+      ? {
+          questionCategory: displayFriend.questionCategory,
+          questionContent: displayFriend.questionContent,
+          answerText: displayFriend.answerText,
+          nickname: displayFriend.nickname,
+        }
+      : null;
+
   return (
     <div
       className={cn(
@@ -45,12 +57,12 @@ const FriendReflectionPanel = ({
             className="-mx-7.5 px-5"
           />
 
-          {displayFriend && (
+          {reflectionDetail && (
             <Detail
-              questionCategory={displayFriend.questionCategory}
-              questionContent={displayFriend.questionContent}
-              answerContent={displayFriend.answerText}
-              friendNickname={displayFriend.nickname}
+              questionCategory={reflectionDetail.questionCategory}
+              questionContent={reflectionDetail.questionContent}
+              answerContent={reflectionDetail.answerText}
+              friendNickname={reflectionDetail.nickname}
             />
           )}
         </div>

--- a/src/components/features/groups/Ranking/RankingItem/RankingItem.stories.tsx
+++ b/src/components/features/groups/Ranking/RankingItem/RankingItem.stories.tsx
@@ -30,6 +30,7 @@ export const WithImage: Story = {
     answerText:
       '오늘 하루도 열심히 살았어요. 회고를 통해 많은 것을 배웠습니다.',
     streakDays: 30,
+    onClick: () => {},
   },
 };
 
@@ -40,6 +41,7 @@ export const WithoutImage: Story = {
     nickname: '수진',
     answerText: '새로운 목표를 세웠어요.',
     streakDays: 15,
+    onClick: () => {},
   },
 };
 
@@ -51,5 +53,6 @@ export const LongAnswerText: Story = {
     answerText:
       '오늘은 정말 긴 회고 내용을 작성했습니다. 이렇게 긴 텍스트는 말줄임표로 잘려서 표시되어야 합니다.',
     streakDays: 7,
+    onClick: () => {},
   },
 };

--- a/src/components/features/groups/Ranking/RankingItem/RankingItem.stories.tsx
+++ b/src/components/features/groups/Ranking/RankingItem/RankingItem.stories.tsx
@@ -10,6 +10,9 @@ const meta = {
     viewport: { defaultViewport: 'mobile1' },
   },
   tags: ['autodocs'],
+  args: {
+    userCategory: 'PRESENT_HEDONISTIC',
+  },
   decorators: [
     (Story) => (
       <ul className="p-4">

--- a/src/components/features/groups/Ranking/RankingItem/RankingItem.tsx
+++ b/src/components/features/groups/Ranking/RankingItem/RankingItem.tsx
@@ -4,6 +4,7 @@ import {
   type Category,
   CATEGORY_CHARACTER_MAP,
 } from '@/src/lib/constants/character';
+import { cn } from '@/src/lib/helpers/cn';
 
 interface RankingItemProps {
   isExistImg: boolean;
@@ -25,7 +26,14 @@ const RankingItem = ({
 }: RankingItemProps) => {
   return (
     <li className="flex items-center gap-3">
-      <div className="text-primary font-button-l">{ranking}</div>
+      <div
+        className={cn(
+          'font-button-l',
+          ranking <= 3 ? 'text-primary' : 'text-g-0',
+        )}
+      >
+        {ranking}
+      </div>
       {isExistImg && (
         <Image
           // TODO: API 반영 후 nullish 제거

--- a/src/components/features/groups/Ranking/RankingItem/RankingItem.tsx
+++ b/src/components/features/groups/Ranking/RankingItem/RankingItem.tsx
@@ -12,8 +12,7 @@ interface RankingItemProps {
   answerText: string;
   streakDays: number;
   ranking: number;
-  // TODO: 사용자의 ZTPI 캐릭터 필요
-  ztpiCharacter?: Category;
+  userCategory: Category;
   onClick: () => void;
 }
 
@@ -23,7 +22,7 @@ const RankingItem = ({
   answerText,
   streakDays,
   ranking,
-  ztpiCharacter,
+  userCategory,
   onClick,
 }: RankingItemProps) => {
   return (
@@ -38,8 +37,7 @@ const RankingItem = ({
       </div>
       {isExistImg && (
         <Image
-          // TODO: API 반영 후 nullish 제거
-          src={CATEGORY_CHARACTER_MAP[ztpiCharacter ?? 'FUTURE'].profileSrc}
+          src={CATEGORY_CHARACTER_MAP[userCategory].profileSrc}
           width="50"
           height="50"
           alt="프로필"

--- a/src/components/features/groups/Ranking/RankingItem/RankingItem.tsx
+++ b/src/components/features/groups/Ranking/RankingItem/RankingItem.tsx
@@ -26,33 +26,39 @@ const RankingItem = ({
   onClick,
 }: RankingItemProps) => {
   return (
-    <li className="flex items-center gap-3 cursor-pointer" onClick={onClick}>
-      <div
-        className={cn(
-          'font-button-l',
-          ranking <= 3 ? 'text-primary' : 'text-g-0',
-        )}
+    <li>
+      <button
+        type="button"
+        className="flex items-center gap-3 w-full cursor-pointer text-left"
+        onClick={onClick}
       >
-        {ranking}
-      </div>
-      {isExistImg && (
-        <Image
-          src={CATEGORY_CHARACTER_MAP[userCategory].profileSrc}
-          width="50"
-          height="50"
-          alt="프로필"
-        />
-      )}
+        <div
+          className={cn(
+            'font-button-l',
+            ranking <= 3 ? 'text-primary' : 'text-g-0',
+          )}
+        >
+          {ranking}
+        </div>
+        {isExistImg && (
+          <Image
+            src={CATEGORY_CHARACTER_MAP[userCategory].profileSrc}
+            width="50"
+            height="50"
+            alt="프로필"
+          />
+        )}
 
-      <div className="min-w-0 flex-1 space-y-1">
-        <p className="font-label-n text-g-0">{nickname}</p>
-        <p className="font-caption-n text-g-60 truncate">{answerText}</p>
-      </div>
+        <div className="min-w-0 flex-1 space-y-1">
+          <p className="font-label-n text-g-0">{nickname}</p>
+          <p className="font-caption-n text-g-60 truncate">{answerText}</p>
+        </div>
 
-      <div>
-        <span className="font-label-n text-g-80">{streakDays}</span>
-        <span className="font-caption-n text-g-80">일</span>
-      </div>
+        <div>
+          <span className="font-label-n text-g-80">{streakDays}</span>
+          <span className="font-caption-n text-g-80">일</span>
+        </div>
+      </button>
     </li>
   );
 };

--- a/src/components/features/groups/Ranking/RankingItem/RankingItem.tsx
+++ b/src/components/features/groups/Ranking/RankingItem/RankingItem.tsx
@@ -14,6 +14,7 @@ interface RankingItemProps {
   ranking: number;
   // TODO: 사용자의 ZTPI 캐릭터 필요
   ztpiCharacter?: Category;
+  onClick: () => void;
 }
 
 const RankingItem = ({
@@ -23,9 +24,10 @@ const RankingItem = ({
   streakDays,
   ranking,
   ztpiCharacter,
+  onClick,
 }: RankingItemProps) => {
   return (
-    <li className="flex items-center gap-3">
+    <li className="flex items-center gap-3 cursor-pointer" onClick={onClick}>
       <div
         className={cn(
           'font-button-l',

--- a/src/components/features/groups/Ranking/RankingList/RankingList.tsx
+++ b/src/components/features/groups/Ranking/RankingList/RankingList.tsx
@@ -55,8 +55,7 @@ const RankingList = ({
           answerText={item.answerText}
           streakDays={item.streakDays}
           ranking={index + 1}
-          // TODO: API 반영 후 변경 필요
-          ztpiCharacter={'FUTURE'}
+          userCategory={item.userCategory}
           onClick={() => onSelect(item)}
         />
       ))}

--- a/src/components/features/groups/Ranking/RankingList/RankingList.tsx
+++ b/src/components/features/groups/Ranking/RankingList/RankingList.tsx
@@ -1,5 +1,6 @@
 import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
 import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
+import { useToast } from '@/src/hooks/useToast';
 
 import type { SortValue } from '../../constants/groupSort';
 import type { GroupType } from '../../constants/groupType';
@@ -20,6 +21,19 @@ const RankingList = ({
   activeTab,
   onSelect,
 }: RankingListProps) => {
+  const { showToast } = useToast();
+
+  const handleSelect = (item: GroupFriendItem) => {
+    if (!item.answerText) {
+      showToast({
+        message: '아직 회고를 작성하지 않았어요.',
+        variant: 'alert',
+      });
+      return;
+    }
+    onSelect(item);
+  };
+
   const { data, isError, isPending } = useGroupFriendListQuery({
     groupId,
     sort,
@@ -56,7 +70,7 @@ const RankingList = ({
           streakDays={item.streakDays}
           ranking={index + 1}
           userCategory={item.userCategory}
-          onClick={() => item.answerText && onSelect(item)}
+          onClick={() => handleSelect(item)}
         />
       ))}
     </ul>

--- a/src/components/features/groups/Ranking/RankingList/RankingList.tsx
+++ b/src/components/features/groups/Ranking/RankingList/RankingList.tsx
@@ -3,6 +3,7 @@ import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
 
 import type { SortValue } from '../../constants/groupSort';
 import type { GroupType } from '../../constants/groupType';
+import type { GroupFriendItem } from '../../queries/useGroupFriendListQuery';
 import { useGroupFriendListQuery } from '../../queries/useGroupFriendListQuery';
 import RankingItem from '../RankingItem/RankingItem';
 
@@ -10,9 +11,15 @@ interface RankingListProps {
   groupId: number;
   sort: SortValue;
   activeTab: GroupType;
+  onSelect: (item: GroupFriendItem) => void;
 }
 
-const RankingList = ({ groupId, sort, activeTab }: RankingListProps) => {
+const RankingList = ({
+  groupId,
+  sort,
+  activeTab,
+  onSelect,
+}: RankingListProps) => {
   const { data, isError, isPending } = useGroupFriendListQuery({
     groupId,
     sort,
@@ -50,6 +57,7 @@ const RankingList = ({ groupId, sort, activeTab }: RankingListProps) => {
           ranking={index + 1}
           // TODO: API 반영 후 변경 필요
           ztpiCharacter={'FUTURE'}
+          onClick={() => onSelect(item)}
         />
       ))}
     </ul>

--- a/src/components/features/groups/Ranking/RankingList/RankingList.tsx
+++ b/src/components/features/groups/Ranking/RankingList/RankingList.tsx
@@ -52,11 +52,11 @@ const RankingList = ({
           isExistImg={activeTab === 'FRIEND'}
           key={item.userId}
           nickname={item.nickname}
-          answerText={item.answerText}
+          answerText={item.answerText ?? ''}
           streakDays={item.streakDays}
           ranking={index + 1}
           userCategory={item.userCategory}
-          onClick={() => onSelect(item)}
+          onClick={() => item.answerText && onSelect(item)}
         />
       ))}
     </ul>

--- a/src/components/features/groups/Ranking/RankingSection/RankingSection.tsx
+++ b/src/components/features/groups/Ranking/RankingSection/RankingSection.tsx
@@ -4,17 +4,20 @@ import { useState } from 'react';
 
 import { SORT_OPTIONS } from '../../constants/groupSort';
 import { type GroupType, groupType } from '../../constants/groupType';
+import type { GroupFriendItem } from '../../queries/useGroupFriendListQuery';
 import RankingList from '../RankingList/RankingList';
 import RankingSort from '../RankingSort/RankingSort';
 
 interface RankingSectionProps {
   activeTab?: GroupType;
   groupId: number;
+  onSelect: (item: GroupFriendItem) => void;
 }
 
 const RankingSection = ({
   activeTab = 'FRIEND',
   groupId,
+  onSelect,
 }: RankingSectionProps) => {
   const [sort, setSort] = useState(SORT_OPTIONS[0].value);
 
@@ -29,7 +32,12 @@ const RankingSection = ({
       </div>
 
       <div className="flex-1 overflow-y-auto pb-24">
-        <RankingList groupId={groupId} sort={sort} activeTab={activeTab} />
+        <RankingList
+          groupId={groupId}
+          sort={sort}
+          activeTab={activeTab}
+          onSelect={onSelect}
+        />
       </div>
     </section>
   );

--- a/src/components/features/groups/queries/useGroupFriendListQuery.ts
+++ b/src/components/features/groups/queries/useGroupFriendListQuery.ts
@@ -16,6 +16,7 @@ export const GroupFriendListSchema = z.object({
   answerText: z.string(),
   streakDays: z.number(),
   totalDays: z.number(),
+  userCategory: z.enum(CATEGORY),
 });
 const ResponseSchema = z.array(GroupFriendListSchema);
 export type GroupFriendItem = z.infer<typeof GroupFriendListSchema>;

--- a/src/components/features/groups/queries/useGroupFriendListQuery.ts
+++ b/src/components/features/groups/queries/useGroupFriendListQuery.ts
@@ -11,9 +11,9 @@ import { GROUP_ENDPOINT } from '../constants/url';
 export const GroupFriendListSchema = z.object({
   userId: z.number(),
   nickname: z.string(),
-  questionContent: z.string(),
-  questionCategory: z.enum(CATEGORY),
-  answerText: z.string(),
+  questionContent: z.string().nullable(),
+  questionCategory: z.enum(CATEGORY).nullable(),
+  answerText: z.string().nullable(),
   streakDays: z.number(),
   totalDays: z.number(),
   userCategory: z.enum(CATEGORY),

--- a/src/components/features/groups/queries/useGroupFriendListQuery.ts
+++ b/src/components/features/groups/queries/useGroupFriendListQuery.ts
@@ -8,7 +8,7 @@ import { sortValueSchema } from '../constants/groupSort';
 import { groupKeys } from '../constants/queryKey';
 import { GROUP_ENDPOINT } from '../constants/url';
 
-const GroupFriendListSchema = z.object({
+export const GroupFriendListSchema = z.object({
   userId: z.number(),
   nickname: z.string(),
   questionContent: z.string(),
@@ -18,6 +18,7 @@ const GroupFriendListSchema = z.object({
   totalDays: z.number(),
 });
 const ResponseSchema = z.array(GroupFriendListSchema);
+export type GroupFriendItem = z.infer<typeof GroupFriendListSchema>;
 type ResponseType = z.infer<typeof ResponseSchema>;
 
 const ParamsSchema = z.object({

--- a/src/components/features/reflectionDetail/Detail/Detail.tsx
+++ b/src/components/features/reflectionDetail/Detail/Detail.tsx
@@ -3,57 +3,39 @@
 import Image from 'next/image';
 
 import Badge from '@/src/components/ui/Badge/Badge';
-import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
-import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
 import { CATEGORY_CHARACTER_MAP } from '@/src/lib/constants/character';
 
 import { getCategoryMessage } from '../../reflectionFeedback/utils/getCategoryMessage';
-import { useReflectionDetail } from '../queries/useReflectionDetail';
+import type {
+  FeedbackType,
+  QuestionType,
+} from '../queries/useReflectionDetail';
 
 interface DetailProps {
-  reflectionId: number;
+  questionCategory: QuestionType['category'];
+  questionContent: QuestionType['content'];
+  feedbackContent?: FeedbackType['content'];
+  answerContent: string;
+  friendNickname?: string;
 }
 
-const Detail = ({ reflectionId }: DetailProps) => {
-  const { data, isPending, isError, refetch } = useReflectionDetail({
-    reflectionId,
-  });
-
-  if (isPending) {
-    return (
-      <div className="space-y-3">
-        <Skeleton className="h-8 w-20" />
-        <Skeleton className="h-10" />
-        <Skeleton className="h-40" />
-        <Skeleton className="h-30" />
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <ErrorState
-        title="회고를 불러오는 데 실패했어요."
-        description="잠시 후 다시 시도해주세요."
-        onRetry={refetch}
-        className="py-15"
-      />
-    );
-  }
-
-  const category = data.question.category;
-  const { src, alt, color } = CATEGORY_CHARACTER_MAP[category];
-  const categoryMessage = getCategoryMessage(category);
+const Detail = ({
+  questionCategory,
+  questionContent,
+  answerContent,
+  feedbackContent,
+  friendNickname,
+}: DetailProps) => {
+  const { src, alt, color } = CATEGORY_CHARACTER_MAP[questionCategory];
+  const categoryMessage = getCategoryMessage(questionCategory);
 
   return (
     <article className="space-y-10">
       <section className="space-y-5">
-        <Badge>나의 기록</Badge>
+        <Badge>{friendNickname ? friendNickname : '나'}의 기록</Badge>
 
-        <h1 className="font-heading-h4 text-primary">
-          {data.question.content}
-        </h1>
-        <p className="font-body-s text-g-60">{data.content}</p>
+        <h1 className="font-heading-h4 text-primary">{questionContent}</h1>
+        <p className="font-body-s text-g-60">{answerContent}</p>
       </section>
 
       <section className="bg-g-20 rounded-2xl p-4 space-y-3">
@@ -67,7 +49,9 @@ const Detail = ({ reflectionId }: DetailProps) => {
           {categoryMessage.suffix}
         </p>
 
-        <p className="font-body-s text-g-600">{data.feedback?.content}</p>
+        {!friendNickname && (
+          <p className="font-body-s text-g-600">{feedbackContent}</p>
+        )}
       </section>
     </article>
   );

--- a/src/components/features/reflectionDetail/Detail/Detail.tsx
+++ b/src/components/features/reflectionDetail/Detail/Detail.tsx
@@ -32,7 +32,7 @@ const Detail = ({
   return (
     <article className="space-y-10">
       <section className="space-y-5">
-        <Badge>{friendNickname ? friendNickname : '나'}의 기록</Badge>
+        <Badge>{friendNickname ? friendNickname : '나'}의 회고</Badge>
 
         <h1 className="font-heading-h4 text-primary">{questionContent}</h1>
         <p className="font-body-s text-g-60">{answerContent}</p>

--- a/src/components/features/reflectionDetail/Detail/ReflectionDetailClient.tsx
+++ b/src/components/features/reflectionDetail/Detail/ReflectionDetailClient.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
+import Skeleton from '@/src/components/ui/Skeleton/Skeleton';
+
+import { useReflectionDetail } from '../queries/useReflectionDetail';
+import Detail from './Detail';
+
+interface ReflectionDetailClientProps {
+  reflectionId: number;
+}
+
+const ReflectionDetailClient = ({
+  reflectionId,
+}: ReflectionDetailClientProps) => {
+  const { data, isPending, isError, refetch } = useReflectionDetail({
+    reflectionId,
+  });
+
+  if (isPending) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-10" />
+        <Skeleton className="h-40" />
+        <Skeleton className="h-30" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorState
+        title="회고를 불러오는 데 실패했어요."
+        description="잠시 후 다시 시도해주세요."
+        onRetry={refetch}
+        className="py-15"
+      />
+    );
+  }
+
+  return (
+    <Detail
+      questionCategory={data.question.category}
+      questionContent={data.question.content}
+      answerContent={data.content}
+      feedbackContent={data.feedback?.content}
+    />
+  );
+};
+
+export default ReflectionDetailClient;

--- a/src/components/features/reflectionDetail/Header/Header.tsx
+++ b/src/components/features/reflectionDetail/Header/Header.tsx
@@ -11,7 +11,7 @@ const Header = () => {
 
   return (
     <PageHeader
-      title="나의 기록"
+      title="나의 회고"
       leftIcon={<Icon name="chevronLeft" size={25} />}
       onLeftClick={() => goBackOrHome(router)}
       className="-mx-7.5 px-5"

--- a/src/components/features/reflectionDetail/queries/useReflectionDetail.ts
+++ b/src/components/features/reflectionDetail/queries/useReflectionDetail.ts
@@ -16,6 +16,8 @@ const QuestionSchema = z.object({
   sequence: z.number(),
 });
 
+export type QuestionType = z.infer<typeof QuestionSchema>;
+
 const FeedbackSchema = z.object({
   content: z.string().nullable(),
   createdAt: z.coerce.date(),
@@ -24,6 +26,8 @@ const FeedbackSchema = z.object({
   score: z.number(),
   status: z.string(),
 });
+
+export type FeedbackType = z.infer<typeof FeedbackSchema>;
 
 const ResponseSchema = z.object({
   id: z.number(),


### PR DESCRIPTION
## What is this PR? :mag:

- 그룹 페이지의 랭킹에서 친구를 클릭하면 친구 회고를 확인할 수 있는 기능 추가

## Changes :memo:

### 친구 회고 확인
나의 회고는 `/reflection/[reflectionId]`로 접근하나, 친구 회고는 특정 id로 친구의 회고를 조회하는 API가 없어 친구 리스트 조회를 활용해야 합니다. 
따라서 친구 랭킹에서 한 친구를 클릭하면 그 회고 데이터를 useState로 저장하고, `FriendReflectionPanel` 컴포넌트에서 렌더링합니다. (id값이 없기 때문에 url로 화면을 이동하지 않고 패널을 통해 렌더링합니다.)

또한, 기존의 나의 회고를 확인하는 컴포넌트를 재사용합니다.
기존의 나의 회고 컴포넌트 (=Detail)는 서버  컴포넌트로부터 reflectionId를 무조건 받아야 했습니다. 친구 회고에서는 reflectionId가 없기 때문에 이를 상위 wrapper로 감싸고 하위 컴포넌트는 재사용이 가능하게끔 했습니다.


### 친구 랭킹에서 사용자의 캐릭터 이미지 추가

TODO로 있었던 사용자의 캐릭터를 프로필에 반영하는 기능을 추가했습니다.

## Related Issues :link:

closes #142 

## Screenshot :camera:

https://github.com/user-attachments/assets/8d6a484f-7fa1-4028-b096-b575a354f758

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ranking items are now clickable, allowing users to view a friend's reflection in a slide-in panel.
  * Added a dedicated reflection panel for viewing friend reflections with improved data display.

* **Bug Fixes**
  * Improved handling of missing reflection data across the application.

* **Documentation**
  * Added component story documentation for `FriendReflectionPanel` and `RankingItem` with multiple usage scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->