### PR TITLE
[Feat] 그룹 생성 후 친구코드 공유 모달 추가

### DIFF
--- a/src/components/features/groups/GroupCreateForm/GroupCreateForm.tsx
+++ b/src/components/features/groups/GroupCreateForm/GroupCreateForm.tsx
@@ -61,10 +61,9 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
             >
               대표 이미지
             </label>
-            <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              className="relative mt-2 w-full aspect-square rounded-2xl bg-g-600 flex items-center justify-center overflow-hidden"
+            <label
+              htmlFor="group-image"
+              className="relative mt-2 w-full aspect-square rounded-2xl bg-g-600 flex items-center justify-center overflow-hidden cursor-pointer"
             >
               {imagePreview ? (
                 <Image
@@ -82,7 +81,7 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
                   alt=""
                 />
               )}
-            </button>
+            </label>
             <input
               ref={fileInputRef}
               id="group-image"
@@ -106,7 +105,6 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
       <GroupShareModal
         isOpen={isSuccessModalOpen}
         onClose={handleCloseSuccessModal}
-        onShare={() => {}}
         groupCode={createdGroupId?.code}
       />
     </>

--- a/src/components/features/groups/GroupCreateForm/GroupCreateForm.tsx
+++ b/src/components/features/groups/GroupCreateForm/GroupCreateForm.tsx
@@ -6,6 +6,7 @@ import BottomCTA from '@/src/components/layout/BottomCTA/BottomCTA';
 import Button from '@/src/components/ui/Button/Button';
 
 import type { GroupType } from '../constants/groupType';
+import GroupShareModal from '../GroupShareModal/GroupShareModal';
 import { useGroupCreate } from '../hooks/useGroupCreate';
 
 interface GroupCreateFormProps {
@@ -21,6 +22,8 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
     isPending,
     handleImageChange,
     handleSubmit,
+    isSuccessModalOpen,
+    handleCloseSuccessModal,
   } = useGroupCreate(type);
 
   return (
@@ -98,6 +101,12 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
           disabled={isPending}
         />
       </BottomCTA>
+
+      <GroupShareModal
+        isOpen={isSuccessModalOpen}
+        onClose={handleCloseSuccessModal}
+        onShare={() => {}}
+      />
     </>
   );
 };

--- a/src/components/features/groups/GroupCreateForm/GroupCreateForm.tsx
+++ b/src/components/features/groups/GroupCreateForm/GroupCreateForm.tsx
@@ -18,7 +18,6 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
     name,
     setName,
     imagePreview,
-    fileInputRef,
     isPending,
     handleImageChange,
     handleSubmit,
@@ -83,7 +82,6 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
               )}
             </label>
             <input
-              ref={fileInputRef}
               id="group-image"
               type="file"
               accept="image/*"

--- a/src/components/features/groups/GroupCreateForm/GroupCreateForm.tsx
+++ b/src/components/features/groups/GroupCreateForm/GroupCreateForm.tsx
@@ -23,7 +23,7 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
     handleSubmit,
     isSuccessModalOpen,
     handleCloseSuccessModal,
-    createdGroupId,
+    createdGroup,
   } = useGroupCreate(type);
 
   return (
@@ -103,7 +103,7 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
       <GroupShareModal
         isOpen={isSuccessModalOpen}
         onClose={handleCloseSuccessModal}
-        groupCode={createdGroupId?.code}
+        groupCode={createdGroup?.code}
       />
     </>
   );

--- a/src/components/features/groups/GroupCreateForm/GroupCreateForm.tsx
+++ b/src/components/features/groups/GroupCreateForm/GroupCreateForm.tsx
@@ -24,6 +24,7 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
     handleSubmit,
     isSuccessModalOpen,
     handleCloseSuccessModal,
+    createdGroupId,
   } = useGroupCreate(type);
 
   return (
@@ -106,6 +107,7 @@ const GroupCreateForm = ({ type }: GroupCreateFormProps) => {
         isOpen={isSuccessModalOpen}
         onClose={handleCloseSuccessModal}
         onShare={() => {}}
+        groupCode={createdGroupId?.code}
       />
     </>
   );

--- a/src/components/features/groups/GroupShareModal/GroupShareModal.tsx
+++ b/src/components/features/groups/GroupShareModal/GroupShareModal.tsx
@@ -1,19 +1,41 @@
+'use client';
+
 import Button from '@/src/components/ui/Button/Button';
 import Modal from '@/src/components/ui/Modal/Modal';
+import { useToast } from '@/src/hooks/useToast';
 
 interface GroupShareModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onShare: () => void;
   groupCode?: string;
 }
 
 const GroupShareModal = ({
   isOpen,
   onClose,
-  onShare,
   groupCode,
 }: GroupShareModalProps) => {
+  const { showToast } = useToast();
+
+  const handleShare = async () => {
+    if (!groupCode) return;
+
+    // TODO: /groups/join 페이지 구현 필요
+    const url = `${window.location.origin}/groups/join?code=${groupCode}`;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: 'TIMO 그룹 초대', url });
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') return;
+        showToast({ message: '공유에 실패했어요.' });
+      }
+    } else if (navigator.clipboard) {
+      await navigator.clipboard.writeText(url);
+      showToast({ message: '초대 링크가 복사되었어요.' });
+    }
+  };
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <div className="flex flex-col gap-6">
@@ -27,7 +49,7 @@ const GroupShareModal = ({
         <div className="flex flex-col gap-4">
           <Button
             label="공유하기"
-            onClick={onShare}
+            onClick={handleShare}
             variant="secondary"
             size="s"
             className="bg-transparent"

--- a/src/components/features/groups/GroupShareModal/GroupShareModal.tsx
+++ b/src/components/features/groups/GroupShareModal/GroupShareModal.tsx
@@ -5,12 +5,14 @@ interface GroupShareModalProps {
   isOpen: boolean;
   onClose: () => void;
   onShare: () => void;
+  groupCode?: string;
 }
 
 const GroupShareModal = ({
   isOpen,
   onClose,
   onShare,
+  groupCode,
 }: GroupShareModalProps) => {
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -20,10 +22,7 @@ const GroupShareModal = ({
           <p className="mt-3 font-body-s text-g-60">
             친구코드 생성이 완료되었습니다.
           </p>
-          <p className="pt-5 font-body-s text-g-20">
-            #코드 번호
-            {/* TODO: 실제 코드 번호 */}
-          </p>
+          <p className="pt-5 font-body-s text-g-20">{groupCode}</p>
         </div>
         <div className="flex flex-col gap-4">
           <Button

--- a/src/components/features/groups/GroupShareModal/GroupShareModal.tsx
+++ b/src/components/features/groups/GroupShareModal/GroupShareModal.tsx
@@ -1,0 +1,43 @@
+import Button from '@/src/components/ui/Button/Button';
+import Modal from '@/src/components/ui/Modal/Modal';
+
+interface GroupShareModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onShare: () => void;
+}
+
+const GroupShareModal = ({
+  isOpen,
+  onClose,
+  onShare,
+}: GroupShareModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="flex flex-col gap-6">
+        <div className="text-center">
+          <h3 className="font-button-l text-primary">코드 생성 완료</h3>
+          <p className="mt-3 font-body-s text-g-60">
+            친구코드 생성이 완료되었습니다.
+          </p>
+          <p className="pt-5 font-body-s text-g-20">
+            #코드 번호
+            {/* TODO: 실제 코드 번호 */}
+          </p>
+        </div>
+        <div className="flex flex-col gap-4">
+          <Button
+            label="공유하기"
+            onClick={onShare}
+            variant="secondary"
+            size="s"
+            className="bg-transparent"
+          />
+          <Button label="완료" onClick={onClose} size="s" />
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default GroupShareModal;

--- a/src/components/features/groups/hooks/useGroupCreate.ts
+++ b/src/components/features/groups/hooks/useGroupCreate.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/navigation';
-import { type ChangeEvent, useEffect, useRef, useState } from 'react';
+import { type ChangeEvent, useEffect, useState } from 'react';
 
 import { useToast } from '@/src/hooks/useToast';
 
@@ -21,7 +21,6 @@ export const useGroupCreate = (type: GroupType) => {
   const [name, setName] = useState('');
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
   const [createdGroupId, setCreatedGroup] =
     useState<CreateGroupResponse | null>(null);
@@ -71,7 +70,6 @@ export const useGroupCreate = (type: GroupType) => {
     name,
     setName,
     imagePreview,
-    fileInputRef,
     isPending,
     handleImageChange,
     handleSubmit,

--- a/src/components/features/groups/hooks/useGroupCreate.ts
+++ b/src/components/features/groups/hooks/useGroupCreate.ts
@@ -4,7 +4,10 @@ import { type ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useToast } from '@/src/hooks/useToast';
 
 import type { GroupType } from '../constants/groupType';
-import { useCreateGroupMutation } from '../queries/useCreateGroupMutation';
+import {
+  type CreateGroupResponse,
+  useCreateGroupMutation,
+} from '../queries/useCreateGroupMutation';
 import { useUploadImageMutation } from '../queries/useUploadImageMutation';
 
 export const useGroupCreate = (type: GroupType) => {
@@ -20,6 +23,8 @@ export const useGroupCreate = (type: GroupType) => {
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
+  const [createdGroupId, setCreatedGroup] =
+    useState<CreateGroupResponse | null>(null);
 
   useEffect(() => {
     return () => {
@@ -49,7 +54,8 @@ export const useGroupCreate = (type: GroupType) => {
 
     try {
       const image = imageFile ? await uploadImage(imageFile) : null;
-      await createGroup({ name: trimmed, type, image });
+      const result = await createGroup({ name: trimmed, type, image });
+      setCreatedGroup(result);
       setIsSuccessModalOpen(true);
     } catch {
       showToast({ message: '그룹 생성에 실패했어요.' });
@@ -71,5 +77,6 @@ export const useGroupCreate = (type: GroupType) => {
     handleSubmit,
     isSuccessModalOpen,
     handleCloseSuccessModal,
+    createdGroupId,
   };
 };

--- a/src/components/features/groups/hooks/useGroupCreate.ts
+++ b/src/components/features/groups/hooks/useGroupCreate.ts
@@ -19,6 +19,7 @@ export const useGroupCreate = (type: GroupType) => {
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
 
   useEffect(() => {
     return () => {
@@ -49,11 +50,15 @@ export const useGroupCreate = (type: GroupType) => {
     try {
       const image = imageFile ? await uploadImage(imageFile) : null;
       await createGroup({ name: trimmed, type, image });
-      // TODO: 그룹 생성 성공 후 코드 공유하기 페이지로 이동
-      router.push('/groups');
+      setIsSuccessModalOpen(true);
     } catch {
       showToast({ message: '그룹 생성에 실패했어요.' });
     }
+  };
+
+  const handleCloseSuccessModal = () => {
+    setIsSuccessModalOpen(false);
+    router.push('/groups');
   };
 
   return {
@@ -64,5 +69,7 @@ export const useGroupCreate = (type: GroupType) => {
     isPending,
     handleImageChange,
     handleSubmit,
+    isSuccessModalOpen,
+    handleCloseSuccessModal,
   };
 };

--- a/src/components/features/groups/hooks/useGroupCreate.ts
+++ b/src/components/features/groups/hooks/useGroupCreate.ts
@@ -22,8 +22,9 @@ export const useGroupCreate = (type: GroupType) => {
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
-  const [createdGroupId, setCreatedGroup] =
-    useState<CreateGroupResponse | null>(null);
+  const [createdGroup, setCreatedGroup] = useState<CreateGroupResponse | null>(
+    null,
+  );
 
   useEffect(() => {
     return () => {
@@ -75,6 +76,6 @@ export const useGroupCreate = (type: GroupType) => {
     handleSubmit,
     isSuccessModalOpen,
     handleCloseSuccessModal,
-    createdGroupId,
+    createdGroup,
   };
 };

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -5,12 +5,14 @@ import { cn } from '@/src/lib/helpers/cn';
 interface ButtonProps extends ComponentProps<'button'> {
   label: string;
   variant?: 'primary' | 'secondary';
+  size?: 'l' | 's';
   disabled?: boolean;
 }
 
 const Button = ({
   label,
   variant = 'primary',
+  size = 'l',
   disabled,
   onClick,
   className,
@@ -27,7 +29,8 @@ const Button = ({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        'h-12 w-full rounded-4xl font-button-l disabled:opacity-50',
+        'h-12 w-full rounded-4xl disabled:opacity-50',
+        size === 's' ? 'font-button-s' : 'font-button-l',
         variantClassName,
         className,
       )}

--- a/src/components/ui/Toast/ToastProvider.tsx
+++ b/src/components/ui/Toast/ToastProvider.tsx
@@ -56,7 +56,7 @@ const ToastProvider = ({ children }: ToastProviderProps) => {
   }, []);
 
   const showToast = useCallback((options: ToastOptions) => {
-    const id = crypto.randomUUID();
+    const id = crypto.randomUUID?.() ?? Math.random().toString(36).slice(2);
     const duration = options.duration ?? DEFAULT_DURATION;
     const variant = options.variant ?? 'check';
 


### PR DESCRIPTION
## What is this PR? :mag:
그룹 생성 성공 후 친구코드를 확인하고 공유할 수 있는 모달을 추가했습니다.

## Changes :memo:
### GroupShareModal 컴포넌트 추가
- 그룹 생성 성공 시 `/groups`로 바로 이동하던 흐름을 친구코드 공유 모달로 변경
- 서버 응답의 `code` 값을 모달에 표시
- 공유하기 버튼: Web Share API로 그룹 참여 URL(`/groups/join?code=`) 공유 예정. -> 현재는 URL 형식만 구성해두었으며 해당 페이지는 #155 머지 후 별도 작업으로 추가할 예정입니다.
- 완료 버튼: 모달 닫고 `/groups`로 이동

### useGroupCreate 훅 수정
- 그룹 생성 성공 응답(`id`, `code`)을 state로 저장
- 성공 후 공유 모달 오픈/클로즈 상태 관리 추가

### Button 컴포넌트
- `size` prop 추가 (`l` | `s`)
- 공유 모달 내 버튼은 디자인상 작은 글씨 크기(`font-button-s`)를 사용해야 하는데, 기존 Button은 `font-button-l`로 고정되어 있어 size prop을 추가했습니다.

### 이미지 업로드 버튼
- `<button onClick={ref.click}>` → `<label htmlFor>` 로 교체
- iOS Safari에서 JS로 직접 `.click()`을 호출하는 방식이 간헐적으로 동작하지 않는 이슈가 있다고 해, 네이티브에서 더 안정적으로 동작하는 `<label htmlFor>` 방식으로 교체했습니다.

### ToastProvider
- `crypto.randomUUID`에 HTTP 환경 fallback 추가
- `crypto.randomUUID`는 HTTPS에서만 동작하는 API여서, HTTP 로컬 원격 접속 시 undefined가 되어 `crypto.randomUUID is not a function` 오류가 발생했습니다 그래서 `crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)` 로 변경했습니다.

## 추가 사항
- 공유하기 버튼의 Web Share API는 HTTPS 환경에서만 동작하여 배포 후 확인 예정입니다.
- 공유 URL(`/groups/join?code=`)로 이동 시 코드가 자동 입력된 참여 모달을 띄우는 작업은 #155 머지 후 별도 PR로 진행할 예정입니다.

## 🙇‍♀️
제가 실수로 main을 잘못 되돌렸다가 복구했습니다. 제대로 복구 한 것 같은데 혹시라도 문제가 생기셨다면 말씀해 주세요. 죄송합니다!! 🙏

## Related Issues :link:
closes #158

## Screenshot :camera:
<img width="454" height="874" alt="image" src="https://github.com/user-attachments/assets/7b35a8e1-096e-44e8-9204-5a3cf4ad0602" />

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “share invite” modal that appears after creating a group, with options to share natively or copy the invite link.

* **Improvements**
  * Refined group image selection to use a more user-friendly preview/label-based picker.
  * Added button size variants (large/small) for more flexible styling.
  * Improved toast ID generation to work reliably in environments without guaranteed UUID support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->