### PR TITLE
[Chore] Context7 MCP 서버 및 /c7 커스텀 커맨드 추가

### DIFF
--- a/.claude/commands/c7.md
+++ b/.claude/commands/c7.md
@@ -1,10 +1,10 @@
 Answer the following question using up-to-date official documentation via Context7 MCP.
 
 Steps:
-1. Read `package.json` to find the exact version of the relevant library
-2. Use Context7 `resolve-library-id` with the library name and version
+1. Read `package.json` to find the exact version of the relevant library. If the library is not found or the question is not library-specific, skip to step 2 without a version.
+2. Use Context7 `resolve-library-id` with the library name (and version if found)
 3. Use Context7 `get-docs` to fetch the documentation
-4. Before answering, output a single line: `[라이브러리 이름 vX.X.X 공식 문서 기준]`
+4. Before answering, output a single line: `[라이브러리 이름 vX.X.X 공식 문서 기준]` (version omitted if not resolved)
 5. Answer based on the fetched docs
 
 Question: $ARGUMENTS

--- a/.claude/commands/c7.md
+++ b/.claude/commands/c7.md
@@ -1,0 +1,10 @@
+Answer the following question using up-to-date official documentation via Context7 MCP.
+
+Steps:
+1. Read `package.json` to find the exact version of the relevant library
+2. Use Context7 `resolve-library-id` with the library name and version
+3. Use Context7 `get-docs` to fetch the documentation
+4. Before answering, output a single line: `[라이브러리 이름 vX.X.X 공식 문서 기준]`
+5. Answer based on the fetched docs
+
+Question: $ARGUMENTS

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## What is this PR? :mag:

Context7 MCP 서버 설정 및 /c7 커스텀 슬래시 커맨드 추가

## Why? :bulb:

AI는 학습 데이터 기준으로 답변하기 때문에 라이브러리가 업데이트돼도 구버전 방식으로 코드를 제안한다 (할루시네이션).
Context7 MCP는 질문 시 해당 라이브러리의 최신 공식 문서를 실시간으로 가져와 근거로 삼는다.

## Changes :memo:

- `.mcp.json` — Context7 MCP 서버 등록
  - pull 후 새 Claude Code 세션에서 팀원 전체 즉시 사용 가능
- `.claude/commands/c7.md` — `/c7` 슬래시 커맨드 추가
  - 매번 `use context7` 수동 입력 대신 `/c7 질문` 형태로 단축
  - `package.json` 버전 자동 확인 → Context7 쿼리 → 참조 버전 명시 → 답변

## How to use :wrench:

```
/c7 TanStack Query에서 onSuccess 콜백 쓰는 법
```
## 문서
[Context7 MCP — AI 최신 문서 동기화 가이드](https://kwonsuhyunportfolio.notion.site/Context7-MCP-AI-389703cb2b4f80f88c85d64c220b4530?source=copy_link) - 이 문서에서 더 자세한 내용 확인 하실 수 있습니다.

## Related Issues :link:

closes #172

## Screenshot :camera:

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command that helps answer questions using the official documentation for a selected library, with the library version clearly included in the response.
  * Added configuration for an integrated documentation lookup service to support this workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->