### PR TITLE
[Feat] 공유 URL 진입 시 친구코드 자동 입력 기능 추가

### DIFF
--- a/app/groups/GroupsPageClient.tsx
+++ b/app/groups/GroupsPageClient.tsx
@@ -17,9 +17,10 @@ import PageHeader from '@/src/components/layout/PageHeader/PageHeader';
 
 interface GroupsPageClientProps {
   joinParam: string | null;
+  code: string | null;
 }
 
-const GroupsPageClient = ({ joinParam }: GroupsPageClientProps) => {
+const GroupsPageClient = ({ joinParam, code }: GroupsPageClientProps) => {
   const [activeTab, setActiveTab] = useState<GroupType>('FRIEND');
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
   const [selectedFriend, setSelectedFriend] = useState<GroupFriendItem | null>(
@@ -81,7 +82,9 @@ const GroupsPageClient = ({ joinParam }: GroupsPageClientProps) => {
       </div>
 
       {joinParam === 'character' && <CharacterGroupJoin />}
-      {joinParam === 'friend' && <FriendGroupJoin />}
+      {joinParam === 'friend' && (
+        <FriendGroupJoin initialCode={code ?? undefined} />
+      )}
     </div>
   );
 };

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -5,15 +5,15 @@ import BottomNavBar from '@/src/components/layout/BottomNavBar/BottomNavBar';
 import GroupsPageClient from './GroupsPageClient';
 
 interface PageProps {
-  searchParams: Promise<{ join?: string }>;
+  searchParams: Promise<{ join?: string; code?: string }>;
 }
 
 export default async function Page({ searchParams }: PageProps) {
-  const { join } = await searchParams;
+  const { join, code } = await searchParams;
 
   return (
     <>
-      <GroupsPageClient joinParam={join ?? null} />
+      <GroupsPageClient joinParam={join ?? null} code={code ?? null} />
       <BottomNavBar />
     </>
   );

--- a/src/components/features/groups/GroupJoin/FriendGroupJoin/FriendGroupJoin.tsx
+++ b/src/components/features/groups/GroupJoin/FriendGroupJoin/FriendGroupJoin.tsx
@@ -3,7 +3,11 @@ import Modal from '@/src/components/ui/Modal/Modal';
 
 import { useFriendGroupJoin } from '../../hooks/useFriendGroupJoin';
 
-const FriendGroupJoin = () => {
+interface FriendGroupJoinProps {
+  initialCode?: string;
+}
+
+const FriendGroupJoin = ({ initialCode }: FriendGroupJoinProps) => {
   const {
     groupCode,
     errorMessage,
@@ -11,7 +15,7 @@ const FriendGroupJoin = () => {
     handleClose,
     handleChange,
     handleSubmit,
-  } = useFriendGroupJoin();
+  } = useFriendGroupJoin(initialCode);
 
   return (
     <Modal isOpen onClose={handleClose}>

--- a/src/components/features/groups/GroupShareModal/GroupShareModal.tsx
+++ b/src/components/features/groups/GroupShareModal/GroupShareModal.tsx
@@ -20,8 +20,7 @@ const GroupShareModal = ({
   const handleShare = async () => {
     if (!groupCode) return;
 
-    // TODO: /groups/join 페이지 구현 필요
-    const url = `${window.location.origin}/groups/join?code=${groupCode}`;
+    const url = `${window.location.origin}/groups?join=friend&code=${groupCode}`;
 
     if (navigator.share) {
       try {

--- a/src/components/features/groups/GroupShareModal/GroupShareModal.tsx
+++ b/src/components/features/groups/GroupShareModal/GroupShareModal.tsx
@@ -30,8 +30,12 @@ const GroupShareModal = ({
         showToast({ message: '공유에 실패했어요.' });
       }
     } else if (navigator.clipboard) {
-      await navigator.clipboard.writeText(url);
-      showToast({ message: '초대 링크가 복사되었어요.' });
+      try {
+        await navigator.clipboard.writeText(url);
+        showToast({ message: '초대 링크가 복사되었어요.' });
+      } catch {
+        showToast({ message: '초대 링크 복사에 실패했어요.' });
+      }
     }
   };
 

--- a/src/components/features/groups/hooks/useFriendGroupJoin.ts
+++ b/src/components/features/groups/hooks/useFriendGroupJoin.ts
@@ -11,9 +11,9 @@ const JOIN_ERROR_MESSAGES: Record<number, string> = {
   409: '이미 참여한 그룹이에요',
 };
 
-export const useFriendGroupJoin = () => {
+export const useFriendGroupJoin = (initialCode?: string) => {
   const router = useRouter();
-  const [groupCode, setGroupCode] = useState('');
+  const [groupCode, setGroupCode] = useState(initialCode ?? '');
   const [errorMessage, setErrorMessage] = useState('');
 
   const { mutate, isPending } = useGroupJoinQuery();


### PR DESCRIPTION
## What is this PR? :mag:
그룹 공유 링크로 진입 시 친구 그룹 참여 모달이 자동으로 열리고, 코드 입력칸이 자동으로 채워지도록 연결했습니다.

**공유 흐름:**
그룹 생성 → 공유 모달에서 "공유하기" 클릭
→ iOS/Android: 네이티브 공유 시트에서 `/groups?join=friend&code=XXXX` URL 공유
→ 링크 받은 사람이 클릭
→ `/groups` 페이지 진입 + 친구 그룹 참여 모달 자동 오픈
→ 코드 입력칸에 `XXXX` 자동 입력 완료

## Changes :memo:
### 코드 자동 입력
- `app/groups/page.tsx`: searchParams에서 `code` 추출해 `GroupsPageClient`로 전달
- `GroupsPageClient`: `code`를 `FriendGroupJoin`의 `initialCode` prop으로 전달
- `FriendGroupJoin` / `useFriendGroupJoin`: `initialCode` 파라미터 추가, `groupCode` 초기값으로 세팅

- ## 추가 사항
- Web Share API는 localhost(localhost는 secure context로 인정돼서 가능하다고 하네요)와 HTTPS에서만 동작합니다. 로컬 IP(예: 192.168.x.x:3000)로 모바일 접속 시 HTTP 환경이라 navigator.share가 undefined가 되어 동작을 확인할 수 없었습니다. 배포 후 실제 모바일 환경(HTTPS)에서 확인이 필요합니다!

## Related Issues :link:
closes #183

## Screenshot :camera:
| 공유 모달 | 공유 후 해당 링크로 접속했을 때 |
|---|---|
| <img width="546" height="888" alt="image" src="https://github.com/user-attachments/assets/b644d3b3-cb10-4fd2-844f-be592050928b" />| <img width="897" height="1016" alt="image" src="https://github.com/user-attachments/assets/460dc450-8048-48a1-bef2-430bf19cbeeb" /> |

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Friend group join links can now include a prefilled code, making it easier to join from shared invites.
  * Group invite links now use a streamlined link format.

* **Bug Fixes**
  * Added a clearer error message when copying an invite link fails.
  * Invite codes from shared links are now carried into the join flow automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->