### PR TITLE
[Feat] 테마·캐릭터 펫 획득 UI 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ storybook-static
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Claude 개인 설정
+.claude/settings.local.json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,8 @@ src/
     layout/       # 페이지 레이아웃 (BottomNavBar, PageHeader, BottomCTA)
     features/     # 기능별 묶음 (home, reflection, reflectionDetail, reflectionFeedback,
                   #   calendar, groups, characters, notification, onboarding, profile,
-                  #   test, testAuth, testResult, serviceFeedback, users, pwa)
+                  #   reward, statistics, test, testAuth, testResult, serviceFeedback,
+                  #   users, pwa)
                   #   각 feature: 컴포넌트 폴더 + queries/ + constants/ + hooks/
   hooks/          # 공용 커스텀 훅 (useToast)
   lib/

--- a/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.stories.tsx
+++ b/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+
+import RewardAcquireScreen from './RewardAcquireScreen';
+
+const meta = {
+  title: 'features/reward/RewardAcquireScreen',
+  component: RewardAcquireScreen,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    onApply: fn(),
+    onSave: fn(),
+  },
+} satisfies Meta<typeof RewardAcquireScreen>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ThemeAcquired: Story = {
+  args: {
+    badgeText: '회고 5회 달성!',
+    rewardName: '00테마',
+    suffix: '를 획득했습니다!',
+  },
+};
+
+export const CharacterPetAcquired: Story = {
+  args: {
+    badgeText: '한 달 연속 회고 달성!',
+    rewardName: '나의 캐릭터 펫',
+    suffix: '을 획득했습니다!',
+  },
+};

--- a/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.tsx
+++ b/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.tsx
@@ -28,7 +28,7 @@ const RewardAcquireScreen = ({
     <div className="fixed inset-y-0 left-1/2 z-50 flex w-full max-w-110 -translate-x-1/2 flex-col bg-g-700 px-7.5">
       <div className="flex flex-1 flex-col items-center justify-center gap-15">
         <div className="relative aspect-269/332 w-full max-w-67 overflow-hidden rounded-2xl bg-g-600">
-          {imageSrc && (
+          {imageSrc ? (
             <Image
               src={imageSrc}
               alt={imageAlt}
@@ -36,7 +36,7 @@ const RewardAcquireScreen = ({
               className="object-cover"
               sizes="(max-width: 440px) 100vw, 440px"
             />
-          )}
+          ) : null}
         </div>
 
         <div className="flex flex-col items-center gap-5">

--- a/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.tsx
+++ b/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.tsx
@@ -25,8 +25,8 @@ const RewardAcquireScreen = ({
   onSave,
 }: RewardAcquireScreenProps) => {
   return (
-    <div className="fixed inset-y-0 left-1/2 z-50 flex w-full max-w-110 -translate-x-1/2 flex-col bg-g-700 px-7.5">
-      <div className="flex flex-1 flex-col items-center justify-center gap-15">
+    <div className="fixed inset-y-0 left-1/2 z-50 flex w-full max-w-110 -translate-x-1/2 flex-col overflow-y-auto bg-g-700 px-7.5 py-8">
+      <div className="my-auto flex flex-col items-center gap-15">
         <div className="relative aspect-269/332 w-full max-w-67 overflow-hidden rounded-2xl bg-g-600">
           {imageSrc ? (
             <Image
@@ -50,7 +50,7 @@ const RewardAcquireScreen = ({
         </div>
       </div>
 
-      <div className="flex flex-col gap-3 pb-8">
+      <div className="mt-8 flex flex-col gap-3">
         <Button label="바로 적용하기" onClick={onApply} />
         <Button label="저장하기" variant="secondary" onClick={onSave} />
       </div>

--- a/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.tsx
+++ b/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.tsx
@@ -1,0 +1,61 @@
+import Image from 'next/image';
+
+import Button from '@/src/components/ui/Button/Button';
+
+interface RewardAcquireScreenProps {
+  badgeText: string;
+  rewardName: string;
+  suffix: string;
+  imageSrc?: string;
+  imageAlt?: string;
+  onApply: () => void;
+  onSave: () => void;
+}
+
+// TODO(#189): 후속 연동 필요
+// - imageSrc: 실제 보상 일러스트 asset/API 연결 (미전달 시 빈 프리뷰 박스)
+// - onApply/onSave: 적용·저장 API 호출 + 완료 모달(홈 이동) 흐름 wiring
+const RewardAcquireScreen = ({
+  badgeText,
+  rewardName,
+  suffix,
+  imageSrc,
+  imageAlt = '',
+  onApply,
+  onSave,
+}: RewardAcquireScreenProps) => {
+  return (
+    <div className="fixed inset-y-0 left-1/2 z-50 flex w-full max-w-110 -translate-x-1/2 flex-col bg-g-700 px-7.5">
+      <div className="flex flex-1 flex-col items-center justify-center gap-15">
+        <div className="relative aspect-269/332 w-full max-w-67 overflow-hidden rounded-2xl bg-g-600">
+          {imageSrc && (
+            <Image
+              src={imageSrc}
+              alt={imageAlt}
+              fill
+              className="object-cover"
+              sizes="(max-width: 440px) 100vw, 440px"
+            />
+          )}
+        </div>
+
+        <div className="flex flex-col items-center gap-5">
+          <span className="rounded-2xl bg-g-300 px-6 py-1 font-label-n text-g-0">
+            {badgeText}
+          </span>
+          <p className="text-center font-heading-h3 text-g-0">
+            <span className="text-primary">{rewardName}</span>
+            {suffix}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 pb-8">
+        <Button label="바로 적용하기" onClick={onApply} />
+        <Button label="저장하기" variant="secondary" onClick={onSave} />
+      </div>
+    </div>
+  );
+};
+
+export default RewardAcquireScreen;

--- a/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.tsx
+++ b/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.tsx
@@ -20,7 +20,7 @@ const RewardAcquireScreen = ({
   rewardName,
   suffix,
   imageSrc,
-  imageAlt = '',
+  imageAlt = `${rewardName} 이미지`,
   onApply,
   onSave,
 }: RewardAcquireScreenProps) => {

--- a/src/components/features/reward/RewardResultModal/RewardResultModal.stories.tsx
+++ b/src/components/features/reward/RewardResultModal/RewardResultModal.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+
+import RewardResultModal from './RewardResultModal';
+
+const meta = {
+  title: 'features/reward/RewardResultModal',
+  component: RewardResultModal,
+  args: {
+    isOpen: true,
+    onClose: fn(),
+  },
+} satisfies Meta<typeof RewardResultModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ThemeApplied: Story = {
+  args: {
+    title: '00테마 적용 완료',
+    description: '00테마 적용이 완료되었습니다',
+    imageSrc: undefined,
+  },
+};
+
+export const ThemeSavedWithViewLink: Story = {
+  args: {
+    title: '00테마 저장 완료',
+    description: '00테마 저장이 완료되었습니다',
+    onView: fn(),
+  },
+};
+
+export const CharacterPetApplied: Story = {
+  args: {
+    title: '나의 캐릭터 펫 적용 완료',
+    description: '나의 캐릭터 펫 적용이 완료되었습니다',
+  },
+};
+
+export const CharacterPetSaved: Story = {
+  args: {
+    title: '나의 캐릭터 펫 저장 완료',
+    description: '나의 캐릭터 펫 저장이 완료되었습니다',
+  },
+};

--- a/src/components/features/reward/RewardResultModal/RewardResultModal.tsx
+++ b/src/components/features/reward/RewardResultModal/RewardResultModal.tsx
@@ -25,7 +25,7 @@ const RewardResultModal = ({
   title,
   description,
   imageSrc,
-  imageAlt = '',
+  imageAlt = title,
   onView,
   viewLabel = '보러가기',
 }: RewardResultModalProps) => {

--- a/src/components/features/reward/RewardResultModal/RewardResultModal.tsx
+++ b/src/components/features/reward/RewardResultModal/RewardResultModal.tsx
@@ -32,7 +32,7 @@ const RewardResultModal = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <div className="flex flex-col gap-6">
-        {imageSrc && (
+        {imageSrc ? (
           <div className="relative aspect-square w-full overflow-hidden rounded-2xl bg-g-600">
             <Image
               src={imageSrc}
@@ -42,7 +42,7 @@ const RewardResultModal = ({
               sizes="(max-width: 440px) 100vw, 440px"
             />
           </div>
-        )}
+        ) : null}
 
         <div className="text-center">
           <h3 className="font-button-l text-primary">{title}</h3>
@@ -51,7 +51,7 @@ const RewardResultModal = ({
 
         <div className="flex flex-col gap-4">
           <Button label="완료" onClick={onClose} size="s" />
-          {onView && (
+          {onView ? (
             <button
               type="button"
               onClick={onView}
@@ -59,7 +59,7 @@ const RewardResultModal = ({
             >
               {viewLabel}
             </button>
-          )}
+          ) : null}
         </div>
       </div>
     </Modal>

--- a/src/components/features/reward/RewardResultModal/RewardResultModal.tsx
+++ b/src/components/features/reward/RewardResultModal/RewardResultModal.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import Image from 'next/image';
+
+import Button from '@/src/components/ui/Button/Button';
+import Modal from '@/src/components/ui/Modal/Modal';
+
+interface RewardResultModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  description: string;
+  imageSrc?: string;
+  imageAlt?: string;
+  onView?: () => void;
+  viewLabel?: string;
+}
+
+// TODO(#189): 후속 연동 필요
+// - imageSrc: 적용 완료 프리뷰 이미지 asset/API 연결
+// - onView: 보러가기 라우팅 연결
+const RewardResultModal = ({
+  isOpen,
+  onClose,
+  title,
+  description,
+  imageSrc,
+  imageAlt = '',
+  onView,
+  viewLabel = '보러가기',
+}: RewardResultModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="flex flex-col gap-6">
+        {imageSrc && (
+          <div className="relative aspect-square w-full overflow-hidden rounded-2xl bg-g-600">
+            <Image
+              src={imageSrc}
+              alt={imageAlt}
+              fill
+              className="object-cover"
+              sizes="(max-width: 440px) 100vw, 440px"
+            />
+          </div>
+        )}
+
+        <div className="text-center">
+          <h3 className="font-button-l text-primary">{title}</h3>
+          <p className="mt-3 font-body-s text-g-60">{description}</p>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <Button label="완료" onClick={onClose} size="s" />
+          {onView && (
+            <button
+              type="button"
+              onClick={onView}
+              className="font-button-s text-primary underline"
+            >
+              {viewLabel}
+            </button>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default RewardResultModal;


### PR DESCRIPTION
## What is this PR? :mag:

회고 마일스톤(회고 5회·한 달 연속 등) 달성 시 얻는 보상(테마·캐릭터 펫)의 **획득 화면 UI**를 구현합니다. (이슈 #189)

사용자 흐름은 두 단계입니다.

1. **획득 화면** — 보상 이미지 + "○○테마를 획득했습니다!" + [바로 적용하기] / [저장하기] 버튼의 풀스크린
2. **완료 모달** — 적용/저장을 누르면 뜨는 "적용 완료" / "저장 완료" 모달

디자인상 테마 3종 + 캐릭터 펫 3종 = 6개 화면이지만, 문구·이미지만 다르고 구조가 동일해 재사용 컴포넌트 2개로 통합했습니다.

보상 관련 백엔드 API와 실제 이미지 asset이 아직 없어(Swagger 확인), 이번 PR은 **UI만** 다룹니다. 데이터 연결이 필요한 지점은 코드에 `TODO(#189)`로 표기했으며, **API·asset이 준비되면 후속 작업으로 작성자가 이어서 진행**합니다.

## Changes :memo:

- `RewardAcquireScreen` — 획득 풀스크린
- `RewardResultModal` — 적용/저장 완료 모달. 기존 공용 `ui/Modal` 재사용
- **6화면 → 2컴포넌트 통합**: 테마↔캐릭터는 props로 분기, 적용↔저장은 `imageSrc`(미리보기)·`onView`(보러가기) 옵션 props로 분기
- **배치**: 두 컴포넌트를 테마·캐릭터가 공유하므로, 한쪽 feature에 두면 다른 feature가 참조하게 되어 cross-feature import가 발생함 → 공통 상위인 `reward` feature에 배치
- 폰트·색상을 Figma와 대조해 디자인 토큰으로 맞춤
- 각 화면의 모든 경우를 Storybook(`features/reward`)에 6종 등록

## Related Issues :link:

close #189

## Screenshot :camera:

실제 라우트 미연결 단계로, 배포된 Storybook에서 확인할 수 있습니다 (획득 2 · 완료 모달 4).

- [획득 화면 (RewardAcquireScreen)](https://6a0747043a4480833f4697f4-scbhjnssyd.chromatic.com/?path=/story/features-reward-rewardacquirescreen--theme-acquired)
- [완료 모달 (RewardResultModal)](https://6a0747043a4480833f4697f4-scbhjnssyd.chromatic.com/?path=/story/features-reward-rewardresultmodal--theme-applied)

보상 이미지 asset이 없는 상태라, 획득 화면은 이미지 영역이 **빈 박스**로, 완료 모달은 미리보기 영역이 **생략**된 채로 렌더됩니다(의도됨 — `imageSrc` 전달 시 표시).

---

### Check List

- [x] 테스트가 전부 통과되었나요? (lint·typecheck 통과, 별도 테스트 미포함)
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요? (main)
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?
