### PR TITLE
[Fix] 그룹 탭 재클릭 시 친구목록 사라지는 버그 수정

### DIFF
--- a/app/groups/GroupsPageClient.tsx
+++ b/app/groups/GroupsPageClient.tsx
@@ -29,6 +29,7 @@ const GroupsPageClient = ({ joinParam, code }: GroupsPageClientProps) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const handleTabChange = (tab: GroupType) => {
+    if (activeTab === tab) return;
     setActiveTab(tab);
     setSelectedGroupId(null);
   };

--- a/app/groups/GroupsPageClient.tsx
+++ b/app/groups/GroupsPageClient.tsx
@@ -32,6 +32,7 @@ const GroupsPageClient = ({ joinParam, code }: GroupsPageClientProps) => {
     if (activeTab === tab) return;
     setActiveTab(tab);
     setSelectedGroupId(null);
+    setSelectedFriend(null);
   };
 
   return (

--- a/src/components/features/test/ViewResultButton/ViewResultButton.tsx
+++ b/src/components/features/test/ViewResultButton/ViewResultButton.tsx
@@ -18,7 +18,7 @@ const ViewResultButton = ({ resultId }: ViewResultButtonProps) => {
   return (
     <Button
       label="결과 확인하기"
-      className="text-g-900 h-10"
+      className="text-g-900"
       onClick={handleViewResultClick}
     />
   );


### PR DESCRIPTION
## What is this PR? :mag:

그룹 탭을 연속으로 두 번 클릭하면 친구 목록이 사라지던 버그를 수정한다. 이미 선택된 그룹 탭을 다시 누르면 선택 해제 로직이 실행되어 목록이 비워지는 게 원인이었고, 이미 눌린 탭을 재클릭했을 때의 토글 동작을 제거해 해결했다.

곁들여 버튼 컴포넌트에 남아있던 불필요한 커스텀 높이 값도 함께 정리했다.

## Changes :memo:

- **그룹 탭 재클릭 버그 수정** (`app/groups/GroupsPageClient.tsx`)
  - 이미 선택된 그룹 탭을 한 번 더 누르면 선택이 풀리며 친구 목록이 사라지던 동작 제거
- **버튼 컴포넌트 정리** (`ViewResultButton.tsx`)
  - 디자인 토큰 기준에 맞지 않는 커스텀 높이 값 삭제

## Related Issues :link:

close #159

## Screenshot :camera:

문제상황은 다음과 같으며, 이 PR을 통해서 그룹 탭 연속 선택을 막았습니다

https://github.com/user-attachments/assets/3b887260-d69e-4291-a440-d8040ac44d45


---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant updates when selecting the currently active group tab.
  * Reset selected group and friend details when switching tabs, keeping displayed content in sync.

* **Style**
  * Adjusted the result-view button’s styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->