### PR TITLE
[Feat] 커스터마이징 획득 화면 API 연동

### DIFF
--- a/app/reward/page.tsx
+++ b/app/reward/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { useRecentlyUnlockedCustomizationsQuery } from '@/src/components/features/reward/queries/useRecentlyUnlockedCustomizationsQuery';
 import RewardUnlockFlow from '@/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow';
@@ -14,17 +14,28 @@ const RewardPage = () => {
 
   const hasNoReward = !isPending && (!data || data.length === 0);
 
+  // 테마를 항상 마지막에 배치 — '보러가기'(테마 전용)를 플로우 끝에서만 노출
+  const sortedItems = useMemo(
+    () =>
+      data
+        ? [...data].sort((a, b) =>
+            a.type === 'THEME' ? 1 : b.type === 'THEME' ? -1 : 0,
+          )
+        : data,
+    [data],
+  );
+
   useEffect(() => {
     if (hasNoReward) {
       router.replace('/');
     }
   }, [hasNoReward, router]);
 
-  if (!data || data.length === 0) {
+  if (!sortedItems || sortedItems.length === 0) {
     return null;
   }
 
-  return <RewardUnlockFlow items={data} onComplete={goHome} />;
+  return <RewardUnlockFlow items={sortedItems} onComplete={goHome} />;
 };
 
 export default RewardPage;

--- a/app/reward/page.tsx
+++ b/app/reward/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { useRecentlyUnlockedCustomizationsQuery } from '@/src/components/features/reward/queries/useRecentlyUnlockedCustomizationsQuery';
+import RewardUnlockFlow from '@/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow';
+
+const RewardPage = () => {
+  const router = useRouter();
+  const { data, isPending } = useRecentlyUnlockedCustomizationsQuery();
+
+  const goHome = () => router.push('/');
+
+  const hasNoReward = !isPending && (!data || data.length === 0);
+
+  useEffect(() => {
+    if (hasNoReward) {
+      router.replace('/');
+    }
+  }, [hasNoReward, router]);
+
+  if (!data || data.length === 0) {
+    return null;
+  }
+
+  return <RewardUnlockFlow items={data} onComplete={goHome} />;
+};
+
+export default RewardPage;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,6 +76,7 @@ Next.js 16의 미들웨어 파일(`proxy` 함수를 export). `config.matcher: ['
 | `/reflection`, `/reflection/[reflectionId]`, `/reflection/[reflectionId]/feedback` | 회고 (목록·상세·피드백) |
 | `/groups`, `/groups/create` | 그룹 회고 (목록·생성) |
 | `/characters` | 캐릭터 선택 |
+| `/reward` | 보상(커스터마이징) 획득 화면 — 회고 피드백 완료 시 해금분 있으면 진입 |
 | `/notification` | 알림 |
 | `/profile`, `/profile/nickname` | 프로필 (프로필·닉네임 변경) |
 | `/test-auth` | 개발용 로그인 |

--- a/src/components/features/reflectionFeedback/CompleteAction/CompleteAction.tsx
+++ b/src/components/features/reflectionFeedback/CompleteAction/CompleteAction.tsx
@@ -7,16 +7,19 @@ import Button from '@/src/components/ui/Button/Button';
 import { useRewardUnlock } from '../../reward/hooks/useRewardUnlock';
 import RewardUnlockFlow from '../../reward/RewardUnlockFlow/RewardUnlockFlow';
 
-const CompleteButton = () => {
+const CompleteAction = () => {
   const router = useRouter();
   const goHome = () => router.push('/');
   const { unlockedItems, isChecking, start } = useRewardUnlock(goHome);
 
-  if (unlockedItems) {
-    return <RewardUnlockFlow items={unlockedItems} onComplete={goHome} />;
-  }
-
-  return <Button label="완료" onClick={start} disabled={isChecking} />;
+  return (
+    <>
+      <Button label="완료" onClick={start} disabled={isChecking} />
+      {unlockedItems ? (
+        <RewardUnlockFlow items={unlockedItems} onComplete={goHome} />
+      ) : null}
+    </>
+  );
 };
 
-export default CompleteButton;
+export default CompleteAction;

--- a/src/components/features/reflectionFeedback/CompleteAction/CompleteAction.tsx
+++ b/src/components/features/reflectionFeedback/CompleteAction/CompleteAction.tsx
@@ -1,25 +1,13 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-
 import Button from '@/src/components/ui/Button/Button';
 
 import { useRewardUnlock } from '../../reward/hooks/useRewardUnlock';
-import RewardUnlockFlow from '../../reward/RewardUnlockFlow/RewardUnlockFlow';
 
 const CompleteAction = () => {
-  const router = useRouter();
-  const goHome = () => router.push('/');
-  const { unlockedItems, isChecking, start } = useRewardUnlock(goHome);
+  const { isChecking, start } = useRewardUnlock();
 
-  return (
-    <>
-      <Button label="완료" onClick={start} disabled={isChecking} />
-      {unlockedItems ? (
-        <RewardUnlockFlow items={unlockedItems} onComplete={goHome} />
-      ) : null}
-    </>
-  );
+  return <Button label="완료" onClick={start} disabled={isChecking} />;
 };
 
 export default CompleteAction;

--- a/src/components/features/reflectionFeedback/CompleteButton/CompleteButton.tsx
+++ b/src/components/features/reflectionFeedback/CompleteButton/CompleteButton.tsx
@@ -4,14 +4,19 @@ import { useRouter } from 'next/navigation';
 
 import Button from '@/src/components/ui/Button/Button';
 
+import { useRewardUnlock } from '../../reward/hooks/useRewardUnlock';
+import RewardUnlockFlow from '../../reward/RewardUnlockFlow/RewardUnlockFlow';
+
 const CompleteButton = () => {
   const router = useRouter();
+  const goHome = () => router.push('/');
+  const { unlockedItems, isChecking, start } = useRewardUnlock(goHome);
 
-  const handleComplete = () => {
-    router.push('/');
-  };
+  if (unlockedItems) {
+    return <RewardUnlockFlow items={unlockedItems} onComplete={goHome} />;
+  }
 
-  return <Button label="완료" onClick={handleComplete} />;
+  return <Button label="완료" onClick={start} disabled={isChecking} />;
 };
 
 export default CompleteButton;

--- a/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
+++ b/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
@@ -9,7 +9,7 @@ import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
 import { goToHome } from '@/src/lib/helpers/navigation';
 
 import { useTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
-import CompleteButton from '../CompleteButton/CompleteButton';
+import CompleteAction from '../CompleteAction/CompleteAction';
 import GeneratingFeedbackCard from '../GeneratingFeedbackCard/GeneratingFeedbackCard';
 import ResultCard from '../ResultCard/ResultCard';
 
@@ -103,7 +103,7 @@ const FeedbackSection = () => {
     <section>
       <ResultCard feedback={feedbackContent} category={category} />
       <BottomCTA>
-        <CompleteButton />
+        <CompleteAction />
       </BottomCTA>
     </section>
   );

--- a/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.stories.tsx
+++ b/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.stories.tsx
@@ -7,6 +7,13 @@ const meta = {
   title: 'features/reward/RewardAcquireScreen',
   component: RewardAcquireScreen,
   parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto min-h-dvh w-full max-w-110 bg-g-700 px-7.5">
+        <Story />
+      </div>
+    ),
+  ],
   args: {
     onApply: fn(),
     onSave: fn(),

--- a/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.tsx
+++ b/src/components/features/reward/RewardAcquireScreen/RewardAcquireScreen.tsx
@@ -12,9 +12,6 @@ interface RewardAcquireScreenProps {
   onSave: () => void;
 }
 
-// TODO(#189): 후속 연동 필요
-// - imageSrc: 실제 보상 일러스트 asset/API 연결 (미전달 시 빈 프리뷰 박스)
-// - onApply/onSave: 적용·저장 API 호출 + 완료 모달(홈 이동) 흐름 wiring
 const RewardAcquireScreen = ({
   badgeText,
   rewardName,
@@ -25,7 +22,7 @@ const RewardAcquireScreen = ({
   onSave,
 }: RewardAcquireScreenProps) => {
   return (
-    <div className="fixed inset-y-0 left-1/2 z-50 flex w-full max-w-110 -translate-x-1/2 flex-col overflow-y-auto bg-g-700 px-7.5 py-8">
+    <div className="flex min-h-dvh flex-col py-8">
       <div className="my-auto flex flex-col items-center gap-15">
         <div className="relative aspect-269/332 w-full max-w-67 overflow-hidden rounded-2xl bg-g-600">
           {imageSrc ? (

--- a/src/components/features/reward/RewardResultModal/RewardResultModal.stories.tsx
+++ b/src/components/features/reward/RewardResultModal/RewardResultModal.stories.tsx
@@ -28,7 +28,7 @@ export const ThemeSavedWithViewLink: Story = {
   args: {
     title: '00테마 저장 완료',
     description: '00테마 저장이 완료되었습니다',
-    onView: fn(),
+    showViewLink: true,
   },
 };
 

--- a/src/components/features/reward/RewardResultModal/RewardResultModal.tsx
+++ b/src/components/features/reward/RewardResultModal/RewardResultModal.tsx
@@ -16,9 +16,6 @@ interface RewardResultModalProps {
   viewLabel?: string;
 }
 
-// TODO(#189): 후속 연동 필요
-// - imageSrc: 적용 완료 프리뷰 이미지 asset/API 연결
-// - onView: 보러가기 라우팅 연결
 const RewardResultModal = ({
   isOpen,
   onClose,

--- a/src/components/features/reward/RewardResultModal/RewardResultModal.tsx
+++ b/src/components/features/reward/RewardResultModal/RewardResultModal.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 
 import Button from '@/src/components/ui/Button/Button';
 import Modal from '@/src/components/ui/Modal/Modal';
+
+import { PROFILE_THEME_ROUTE } from '../constants/url';
 
 interface RewardResultModalProps {
   isOpen: boolean;
@@ -12,7 +15,7 @@ interface RewardResultModalProps {
   description: string;
   imageSrc?: string;
   imageAlt?: string;
-  onView?: () => void;
+  showViewLink?: boolean;
   viewLabel?: string;
 }
 
@@ -23,7 +26,7 @@ const RewardResultModal = ({
   description,
   imageSrc,
   imageAlt = title,
-  onView,
+  showViewLink = false,
   viewLabel = '보러가기',
 }: RewardResultModalProps) => {
   return (
@@ -48,14 +51,13 @@ const RewardResultModal = ({
 
         <div className="flex flex-col gap-4">
           <Button label="완료" onClick={onClose} size="s" />
-          {onView ? (
-            <button
-              type="button"
-              onClick={onView}
-              className="font-button-s text-primary underline"
+          {showViewLink ? (
+            <Link
+              href={PROFILE_THEME_ROUTE}
+              className="text-center font-button-s text-primary underline"
             >
               {viewLabel}
-            </button>
+            </Link>
           ) : null}
         </div>
       </div>

--- a/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow.tsx
+++ b/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow.tsx
@@ -88,7 +88,11 @@ const RewardUnlockFlow = ({ items, onComplete }: RewardUnlockFlowProps) => {
       title={`${subject} ${actionLabel} 완료`}
       description={`${subject} ${actionLabel}이 완료되었습니다`}
       imageSrc={isApplied ? current.image : undefined}
-      onView={!isApplied && isTheme ? handleView : undefined}
+      onView={
+        index === items.length - 1 && !isApplied && isTheme
+          ? handleView
+          : undefined
+      }
     />
   );
 };

--- a/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow.tsx
+++ b/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { useToast } from '@/src/hooks/useToast';
@@ -23,7 +22,6 @@ const RewardUnlockFlow = ({ items, onComplete }: RewardUnlockFlowProps) => {
   const [phase, setPhase] = useState<Phase>('acquire');
   const { mutateAsync: equip, isPending } = useEquipCustomizationMutation();
   const { showToast } = useToast();
-  const router = useRouter();
 
   const current = items[index];
   if (!current) {
@@ -55,9 +53,6 @@ const RewardUnlockFlow = ({ items, onComplete }: RewardUnlockFlowProps) => {
 
   const handleSave = () => setPhase('saved');
 
-  // TODO(#193): 보러가기 목적지 경로 확인 필요 (/profile/theme)
-  const handleView = () => router.push('/profile/theme');
-
   const isTheme = current.type === 'THEME';
   const subject = isTheme ? current.name : '나의 캐릭터 펫';
   const acquireSuffix = isTheme ? '를 획득했습니다!' : '을 획득했습니다!';
@@ -88,11 +83,7 @@ const RewardUnlockFlow = ({ items, onComplete }: RewardUnlockFlowProps) => {
       title={`${subject} ${actionLabel} 완료`}
       description={`${subject} ${actionLabel}이 완료되었습니다`}
       imageSrc={isApplied ? current.image : undefined}
-      onView={
-        index === items.length - 1 && !isApplied && isTheme
-          ? handleView
-          : undefined
-      }
+      showViewLink={index === items.length - 1 && !isApplied && isTheme}
     />
   );
 };

--- a/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow.tsx
+++ b/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow.tsx
@@ -66,7 +66,7 @@ const RewardUnlockFlow = ({ items, onComplete }: RewardUnlockFlowProps) => {
         )}
         rewardName={subject}
         suffix={acquireSuffix}
-        imageSrc={current.image}
+        imageSrc={current.image ?? undefined}
         onApply={handleApply}
         onSave={handleSave}
       />
@@ -82,7 +82,7 @@ const RewardUnlockFlow = ({ items, onComplete }: RewardUnlockFlowProps) => {
       onClose={goNext}
       title={`${subject} ${actionLabel} 완료`}
       description={`${subject} ${actionLabel}이 완료되었습니다`}
-      imageSrc={isApplied ? current.image : undefined}
+      imageSrc={isApplied ? (current.image ?? undefined) : undefined}
       showViewLink={index === items.length - 1 && !isApplied && isTheme}
     />
   );

--- a/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow.tsx
+++ b/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow.tsx
@@ -59,7 +59,7 @@ const RewardUnlockFlow = ({ items, onComplete }: RewardUnlockFlowProps) => {
   const handleView = () => router.push('/profile/theme');
 
   const isTheme = current.type === 'THEME';
-  const subject = isTheme ? `${current.name}테마` : '나의 캐릭터 펫';
+  const subject = isTheme ? current.name : '나의 캐릭터 펫';
   const acquireSuffix = isTheme ? '를 획득했습니다!' : '을 획득했습니다!';
 
   if (phase === 'acquire') {

--- a/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow.tsx
+++ b/src/components/features/reward/RewardUnlockFlow/RewardUnlockFlow.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { useToast } from '@/src/hooks/useToast';
+
+import { useEquipCustomizationMutation } from '../queries/useEquipCustomizationMutation';
+import type { UnlockedCustomizationItem } from '../queries/useRecentlyUnlockedCustomizationsQuery';
+import RewardAcquireScreen from '../RewardAcquireScreen/RewardAcquireScreen';
+import RewardResultModal from '../RewardResultModal/RewardResultModal';
+import { getUnlockBadgeText } from '../utils/getUnlockBadgeText';
+
+type Phase = 'acquire' | 'applied' | 'saved';
+
+interface RewardUnlockFlowProps {
+  items: UnlockedCustomizationItem[];
+  onComplete: () => void;
+}
+
+const RewardUnlockFlow = ({ items, onComplete }: RewardUnlockFlowProps) => {
+  const [index, setIndex] = useState(0);
+  const [phase, setPhase] = useState<Phase>('acquire');
+  const { mutateAsync: equip, isPending } = useEquipCustomizationMutation();
+  const { showToast } = useToast();
+  const router = useRouter();
+
+  const current = items[index];
+  if (!current) {
+    return null;
+  }
+
+  const goNext = () => {
+    const nextIndex = index + 1;
+    if (nextIndex >= items.length) {
+      onComplete();
+      return;
+    }
+    setIndex(nextIndex);
+    setPhase('acquire');
+  };
+
+  const handleApply = async () => {
+    if (isPending) {
+      return;
+    }
+
+    try {
+      await equip(current.id);
+      setPhase('applied');
+    } catch {
+      showToast({ message: '적용에 실패했어요.' });
+    }
+  };
+
+  const handleSave = () => setPhase('saved');
+
+  // TODO(#193): 보러가기 목적지 경로 확인 필요 (/profile/theme)
+  const handleView = () => router.push('/profile/theme');
+
+  const isTheme = current.type === 'THEME';
+  const subject = isTheme ? `${current.name}테마` : '나의 캐릭터 펫';
+  const acquireSuffix = isTheme ? '를 획득했습니다!' : '을 획득했습니다!';
+
+  if (phase === 'acquire') {
+    return (
+      <RewardAcquireScreen
+        badgeText={getUnlockBadgeText(
+          current.unlockConditionType,
+          current.unlockConditionCount,
+        )}
+        rewardName={subject}
+        suffix={acquireSuffix}
+        imageSrc={current.image}
+        onApply={handleApply}
+        onSave={handleSave}
+      />
+    );
+  }
+
+  const isApplied = phase === 'applied';
+  const actionLabel = isApplied ? '적용' : '저장';
+
+  return (
+    <RewardResultModal
+      isOpen
+      onClose={goNext}
+      title={`${subject} ${actionLabel} 완료`}
+      description={`${subject} ${actionLabel}이 완료되었습니다`}
+      imageSrc={isApplied ? current.image : undefined}
+      onView={!isApplied && isTheme ? handleView : undefined}
+    />
+  );
+};
+
+export default RewardUnlockFlow;

--- a/src/components/features/reward/constants/queryKeys.ts
+++ b/src/components/features/reward/constants/queryKeys.ts
@@ -1,0 +1,6 @@
+export const customizationKeys = {
+  all: ['customizations'] as const,
+  recentlyUnlocked: () =>
+    [...customizationKeys.all, 'recentlyUnlocked'] as const,
+  equip: () => [...customizationKeys.all, 'equip'] as const,
+};

--- a/src/components/features/reward/constants/url.ts
+++ b/src/components/features/reward/constants/url.ts
@@ -1,5 +1,7 @@
 export const REWARD_ROUTE = '/reward';
 
+export const PROFILE_THEME_ROUTE = '/profile/theme';
+
 export const CUSTOMIZATION_ENDPOINTS = {
   recentlyUnlocked: '/customizations/recently-unlocked',
   equip: (customizationItemId: number) =>

--- a/src/components/features/reward/constants/url.ts
+++ b/src/components/features/reward/constants/url.ts
@@ -1,3 +1,5 @@
+export const REWARD_ROUTE = '/reward';
+
 export const CUSTOMIZATION_ENDPOINTS = {
   recentlyUnlocked: '/customizations/recently-unlocked',
   equip: (customizationItemId: number) =>

--- a/src/components/features/reward/constants/url.ts
+++ b/src/components/features/reward/constants/url.ts
@@ -1,0 +1,5 @@
+export const CUSTOMIZATION_ENDPOINTS = {
+  recentlyUnlocked: '/customizations/recently-unlocked',
+  equip: (customizationItemId: number) =>
+    `/customizations/${customizationItemId}/equip`,
+} as const;

--- a/src/components/features/reward/hooks/useRewardUnlock.ts
+++ b/src/components/features/reward/hooks/useRewardUnlock.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { useToast } from '@/src/hooks/useToast';
+
+import { customizationKeys } from '../constants/queryKeys';
+import {
+  getRecentlyUnlockedCustomizations,
+  type UnlockedCustomizationItem,
+} from '../queries/useRecentlyUnlockedCustomizationsQuery';
+
+export const useRewardUnlock = (onFinish: () => void) => {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+  const [unlockedItems, setUnlockedItems] = useState<
+    UnlockedCustomizationItem[] | null
+  >(null);
+  const [isChecking, setIsChecking] = useState(false);
+
+  const start = async () => {
+    if (isChecking) {
+      return;
+    }
+
+    setIsChecking(true);
+    try {
+      const items = await queryClient.fetchQuery({
+        queryKey: customizationKeys.recentlyUnlocked(),
+        queryFn: getRecentlyUnlockedCustomizations,
+      });
+
+      if (items.length > 0) {
+        setUnlockedItems(items);
+        return;
+      }
+
+      onFinish();
+    } catch {
+      showToast({ message: '보상 정보를 불러오지 못했어요.' });
+      onFinish();
+    } finally {
+      setIsChecking(false);
+    }
+  };
+
+  return { unlockedItems, isChecking, start };
+};

--- a/src/components/features/reward/hooks/useRewardUnlock.ts
+++ b/src/components/features/reward/hooks/useRewardUnlock.ts
@@ -1,22 +1,19 @@
 'use client';
 
 import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { useToast } from '@/src/hooks/useToast';
 
 import { customizationKeys } from '../constants/queryKeys';
-import {
-  getRecentlyUnlockedCustomizations,
-  type UnlockedCustomizationItem,
-} from '../queries/useRecentlyUnlockedCustomizationsQuery';
+import { REWARD_ROUTE } from '../constants/url';
+import { getRecentlyUnlockedCustomizations } from '../queries/useRecentlyUnlockedCustomizationsQuery';
 
-export const useRewardUnlock = (onFinish: () => void) => {
+export const useRewardUnlock = () => {
+  const router = useRouter();
   const queryClient = useQueryClient();
   const { showToast } = useToast();
-  const [unlockedItems, setUnlockedItems] = useState<
-    UnlockedCustomizationItem[] | null
-  >(null);
   const [isChecking, setIsChecking] = useState(false);
 
   const start = async () => {
@@ -31,19 +28,14 @@ export const useRewardUnlock = (onFinish: () => void) => {
         queryFn: getRecentlyUnlockedCustomizations,
       });
 
-      if (items.length > 0) {
-        setUnlockedItems(items);
-        return;
-      }
-
-      onFinish();
+      router.push(items.length > 0 ? REWARD_ROUTE : '/');
     } catch {
       showToast({ message: '보상 정보를 불러오지 못했어요.' });
-      onFinish();
+      router.push('/');
     } finally {
       setIsChecking(false);
     }
   };
 
-  return { unlockedItems, isChecking, start };
+  return { isChecking, start };
 };

--- a/src/components/features/reward/queries/useEquipCustomizationMutation.ts
+++ b/src/components/features/reward/queries/useEquipCustomizationMutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { post } from '@/src/lib/api';
 
@@ -8,14 +8,8 @@ import { CUSTOMIZATION_ENDPOINTS } from '../constants/url';
 const equipCustomization = async (customizationItemId: number): Promise<void> =>
   post<never, void>(CUSTOMIZATION_ENDPOINTS.equip(customizationItemId));
 
-export const useEquipCustomizationMutation = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
+export const useEquipCustomizationMutation = () =>
+  useMutation({
     mutationKey: customizationKeys.equip(),
     mutationFn: equipCustomization,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: customizationKeys.all });
-    },
   });
-};

--- a/src/components/features/reward/queries/useEquipCustomizationMutation.ts
+++ b/src/components/features/reward/queries/useEquipCustomizationMutation.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { post } from '@/src/lib/api';
+
+import { customizationKeys } from '../constants/queryKeys';
+import { CUSTOMIZATION_ENDPOINTS } from '../constants/url';
+
+const equipCustomization = async (customizationItemId: number): Promise<void> =>
+  post<never, void>(CUSTOMIZATION_ENDPOINTS.equip(customizationItemId));
+
+export const useEquipCustomizationMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: customizationKeys.equip(),
+    mutationFn: equipCustomization,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: customizationKeys.all });
+    },
+  });
+};

--- a/src/components/features/reward/queries/useRecentlyUnlockedCustomizationsQuery.ts
+++ b/src/components/features/reward/queries/useRecentlyUnlockedCustomizationsQuery.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { get } from '@/src/lib/api';
+
+import { customizationKeys } from '../constants/queryKeys';
+import { CUSTOMIZATION_ENDPOINTS } from '../constants/url';
+
+const customizationTypeSchema = z.enum(['THEME', 'DECORATION']);
+const unlockConditionTypeSchema = z.enum(['TOTAL_COUNT', 'STREAK_COUNT']);
+
+const unlockedCustomizationItemSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  type: customizationTypeSchema,
+  description: z.string(),
+  unlockConditionType: unlockConditionTypeSchema,
+  unlockConditionCount: z.number(),
+  image: z.string(),
+});
+
+const recentlyUnlockedCustomizationsSchema = z.array(
+  unlockedCustomizationItemSchema,
+);
+
+export type CustomizationType = z.infer<typeof customizationTypeSchema>;
+export type UnlockConditionType = z.infer<typeof unlockConditionTypeSchema>;
+export type UnlockedCustomizationItem = z.infer<
+  typeof unlockedCustomizationItemSchema
+>;
+
+export const getRecentlyUnlockedCustomizations = async () =>
+  get<UnlockedCustomizationItem[]>(CUSTOMIZATION_ENDPOINTS.recentlyUnlocked, {
+    responseSchema: recentlyUnlockedCustomizationsSchema,
+  });
+
+export const useRecentlyUnlockedCustomizationsQuery = () =>
+  useQuery({
+    queryKey: customizationKeys.recentlyUnlocked(),
+    queryFn: getRecentlyUnlockedCustomizations,
+  });

--- a/src/components/features/reward/queries/useRecentlyUnlockedCustomizationsQuery.ts
+++ b/src/components/features/reward/queries/useRecentlyUnlockedCustomizationsQuery.ts
@@ -16,7 +16,8 @@ const unlockedCustomizationItemSchema = z.object({
   description: z.string(),
   unlockConditionType: unlockConditionTypeSchema,
   unlockConditionCount: z.number(),
-  image: z.string(),
+  image: z.string().nullish(),
+  imageWithoutBackground: z.string().nullish(),
 });
 
 const recentlyUnlockedCustomizationsSchema = z.array(

--- a/src/components/features/reward/utils/getUnlockBadgeText.ts
+++ b/src/components/features/reward/utils/getUnlockBadgeText.ts
@@ -1,0 +1,13 @@
+import type { UnlockConditionType } from '../queries/useRecentlyUnlockedCustomizationsQuery';
+
+export const getUnlockBadgeText = (
+  unlockConditionType: UnlockConditionType,
+  unlockConditionCount: number,
+): string => {
+  switch (unlockConditionType) {
+    case 'TOTAL_COUNT':
+      return `회고 ${unlockConditionCount}회 달성!`;
+    case 'STREAK_COUNT':
+      return `${unlockConditionCount}일 연속 회고 달성!`;
+  }
+};


### PR DESCRIPTION
## What is this PR? :mag:

- 회고를 꾸준히 하면 해금되는 보상(테마·펫)을, **회고 피드백 완료 시점에 획득 화면으로 보여주는** 기능을 구현했습니다.
- (이슈 #193) [PR #191](https://github.com/dnd-side-project/dnd-14th-5-frontend/pull/191)에서 만든 획득 UI를 실제 API에 연결했습니다.
- 획득 화면은 전체를 차지하는 독립 화면이라, 오버레이 대신 별도 페이지(`/reward`)로 구현했습니다. (상세는 아래 Changes)

**흐름:** 피드백 완료 버튼 → `GET /customizations/recently-unlocked` 조회 → 해금된 보상이 있으면 `/reward` 페이지로 이동해 **획득 → 적용/저장**을 순차로 보여주고, 없으면 홈으로 이동합니다.

## Changes :memo:

- **커스터마이징 API 연동** — 해금된 보상을 조회(`GET /customizations/recently-unlocked`)하고 적용/장착(`POST .../equip`)하는 API를 붙였습니다. 응답은 Zod로 검증합니다.
- **뱃지 문구 생성** — "무엇으로 해금됐는지"(누적 N회 / 연속 N일)를 백엔드가 응답에 담아주므로, 그 값을 "회고 N회 달성"·"N일 연속 회고 달성" 문구로 변환합니다. (프론트가 회고 수를 직접 세지 않아도 되도록)
- **여러 개 동시 해금 처리** — 한 번에 여러 보상이 해금될 수 있어, **획득→적용/저장→다음** 순으로 하나씩 순차 표시하는 흐름을 만들었습니다. "적용"은 장착 API를 호출하고, "저장"은 완료 모달만 띄웁니다(저장한 보상은 추후 다른 화면에서 확인).
- **진입 지점** — 회고 피드백의 "완료" 버튼을 누르면 해금분을 조회해, 있으면 획득 화면으로 / 없으면 홈으로 이동합니다.
- **설계 결정 — 획득 화면을 오버레이가 아닌 `/reward` 라우트로**: 처음엔 `fixed` 오버레이로 만들었으나, 부모(`BottomCTA`)의 `transform` 때문에 `fixed`가 뷰포트가 아닌 부모 기준으로 배치되는 문제가 있었습니다. 획득 화면은 전체를 차지하는 독립 화면이라 별도 라우트로 분리해 `fixed`·portal 없이 일반 페이지로 렌더했고, 이 과정에서 무거운 흐름 컴포넌트를 `app/` 라우트가 소유하게 되어 feature 간 결합도 줄었습니다.
- **보상 종류별 문구 분기** — 테마는 실제 이름("학교 테마"), 캐릭터 펫은 "나의 캐릭터 펫" 고정 문구를 사용합니다.

**구조 요약**

```text
app/reward/page.tsx                        획득 화면 라우트 (해금분 없으면 홈으로)
src/components/features/reward/
  ├─ queries/                              커스터마이징 API (조회·장착) + Zod 스키마
  ├─ constants/ (url·queryKeys)            엔드포인트·라우트·쿼리키
  ├─ utils/getUnlockBadgeText              해금 조건 → 뱃지 문구 변환
  ├─ RewardUnlockFlow/                     획득→적용/저장 순차 오케스트레이션
  └─ hooks/useRewardUnlock                 완료 시 조회 후 페이지 이동 트리거
src/components/features/reflectionFeedback/
  └─ CompleteAction/                       피드백 완료 버튼 (진입점)
```

## Related Issues :link:

close #193

## Screenshot :camera:

https://github.com/user-attachments/assets/ce73147e-4296-46ef-9ad9-042ffdfb30e3

- 우선 테스트 계정으로 **테마 획득 흐름**은 확인했습니다.
- **펫 획득 · 캐릭터/펫 동시 획득** 흐름은 테스트 계정 문제로 아직 확인하지 못했습니다. 대신 **mock 데이터로 순차 동작을 확인**했고, 계정 문제 해결되면 한 번 더 확인하겠습니다.
- 이미지 asset이 아직 BE에서 오지 않아(현재 `image: ""`) 프리뷰는 빈 박스로 렌더됩니다.

**후속 (의존 준비되면 진행):** 이미지 https URL 확정 시 `next.config` `remotePatterns`에 호스트 추가 / recently-unlocked 재노출 규칙 확인 / 보러가기 목적지 경로(`/profile/theme`) 확정. 관련 항목은 **이 PR 머지 후** 이어서 처리하겠습니다.

---

### Check List

- [x] 테스트가 전부 통과되었나요? (lint·typecheck 통과, mock으로 순차 흐름 검증)
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요? (base: `feature/theme-character-pet-acquire-#189` 스택, #191 머지 후 main 재타겟)
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?
