### PR TITLE
[Fix] 회고 작성 시 그룹 친구 랭킹 캐시 갱신

### DIFF
--- a/src/components/features/reflection/queries/useSubmitReflectionMutation.ts
+++ b/src/components/features/reflection/queries/useSubmitReflectionMutation.ts
@@ -1,6 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
+import { groupKeys } from '@/src/components/features/groups/constants/queryKey';
 import { post } from '@/src/lib/api';
 
 import { reflectionKeys } from '../constants/queryKeys';
@@ -32,17 +33,14 @@ const submitReflection = async ({ content }: SubmitReflectionRequestType) => {
   );
 };
 
-interface UseSubmitReflectionMutationOptions {
-  onSuccess?: (data: SubmitReflectionResponseType) => void;
-  onError?: () => void;
-}
+export const useSubmitReflectionMutation = () => {
+  const queryClient = useQueryClient();
 
-export const useSubmitReflectionMutation = (
-  options?: UseSubmitReflectionMutationOptions,
-) =>
-  useMutation({
+  return useMutation({
     mutationKey: reflectionKeys.submitReflection(),
     mutationFn: submitReflection,
-    onSuccess: options?.onSuccess,
-    onError: options?.onError,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: groupKeys.all() });
+    },
   });
+};


### PR DESCRIPTION
## What is this PR? :mag:

회고를 작성한 직후 그룹 탭 → 친구 랭킹에서 본인을 클릭하면 방금 쓴 회고가 아니라 "아직 회고를 작성하지 않았어요"로 잘못 표시되는 버그를 고쳤습니다.

원인은 그룹 친구 랭킹 쿼리(`useGroupFriendListQuery`)의 `staleTime`이 5분으로 설정돼 있는데, 회고 제출 뮤테이션이 이 쿼리를 무효화하지 않았기 때문입니다. 그룹 탭을 한 번이라도 방문해 캐시가 생긴 그룹은 회고를 새로 작성해도 stale 캐시를 그대로 보여주고, 아직 방문하지 않아 캐시가 없는 그룹만 fresh fetch로 정상 표시되는 식이었습니다.

## Changes :memo:

- `useSubmitReflectionMutation`의 `onSuccess`에서 `groupKeys.all()` 쿼리를 invalidate하도록 추가
- 안 쓰이던 `options`(`onSuccess`/`onError`) 파라미터는 실제 호출부(`useReflectionForm`)에서 사용하지 않아 함께 제거

무효화 로직은 쿼리 소비 쪽(`useReflectionForm`)이 아니라 뮤테이션 정의 쪽(`useSubmitReflectionMutation`)에 두어, 회고 제출을 트리거하는 다른 호출부가 생기더라도 그룹 랭킹 캐시 갱신을 매번 신경 쓸 필요 없게 했습니다.

**재현/검증**: API를 목킹한 Playwright 시나리오로 "캐시된 그룹은 회고 미작성으로 잘못 표시 / 캐시 없는 그룹은 정상 표시"되는 증상을 재현해 원인을 확인했습니다

## Related Issues :link:

close #200

## Screenshot :camera:

해당 없음 (UI 변경 없음, 데이터 캐시 로직 수정)

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?