### PR TITLE
[Fix] 알림 목록을 최신순으로 정렬

### DIFF
--- a/src/components/features/notification/hooks/useNotificationReadActions.ts
+++ b/src/components/features/notification/hooks/useNotificationReadActions.ts
@@ -17,7 +17,9 @@ export const useNotificationReadActions = () => {
   const { data, isPending } = useNotificationHistoriesQuery();
   const { mutateAsync: readNotificationHistory, isPending: isMutating } =
     useReadNotificationHistoryMutation();
-  const notifications = data ?? [];
+  const notifications = [...(data ?? [])].sort(
+    (a, b) => b.notifiedAt.getTime() - a.notifiedAt.getTime(),
+  );
 
   const refetchNotifications = () => {
     queryClient.invalidateQueries({


### PR DESCRIPTION
## What is this PR? :mag:

알림 목록이 오름차순으로 정렬된 것을 내림차순(최신순)으로 정렬

## Changes :memo:

- 알림 목록을 notifiedAt 기준 내림차순(최신순)으로 정렬

## Related Issues :link:

closes #199

## Screenshot :camera:

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?