### PR TITLE
[Chore] S3 업로드 이미지 호스트 허용 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -37,6 +37,11 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'api.timo.io.kr',
       },
+      {
+        protocol: 'https',
+        hostname:
+          'timo-uploads-216016752848-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com',
+      },
     ],
   },
 };


### PR DESCRIPTION
## What is this PR? :mag:

그룹 프로필 등에서 S3에 업로드된 이미지를 `next/image`로 렌더링하면 Next Image Optimization의 허용 호스트 목록(`remotePatterns`)에 없어 이미지가 깨진다. S3 버킷 호스트를 허용 목록에 추가해 정상 렌더링되도록 한다.

## Changes :memo:

- `next.config.ts`의 `images.remotePatterns`에 S3 업로드 버킷 호스트(`timo-uploads-216016752848-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com`) 추가

## Related Issues :link:

없음

## Screenshot :camera:

해당 없음

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled images hosted on an approved external source to load correctly through image optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->