### PR TITLE
[Feat] 그룹 랭킹 화면에 다이얼 인디케이터 추가

### DIFF
--- a/src/components/features/groups/GroupList/GroupList.stories.tsx
+++ b/src/components/features/groups/GroupList/GroupList.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { useState } from 'react';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fireEvent, fn, waitFor, within } from 'storybook/test';
 
 import RankingItem from '@/src/components/features/groups/Ranking/RankingItem/RankingItem';
 
@@ -107,10 +107,8 @@ export const DialScroll: Story = {
     scrollContainer.dispatchEvent(new Event('scroll'));
     scrollContainer.dispatchEvent(new Event('scrollend'));
 
-    // scrollend 미지원 환경의 debounce(120ms) 폴백까지 여유를 둔다
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
-    await expect(args.onSelect).toHaveBeenCalled();
+    // scrollend 미지원 환경의 debounce(120ms) 폴백까지 여유를 두고 폴링한다
+    await waitFor(() => expect(args.onSelect).toHaveBeenCalled());
 
     const canvas = within(canvasElement);
     const focusedButton = canvas.getAllByRole('button', { pressed: true })[0];
@@ -143,21 +141,28 @@ export const DialEdgeClick: Story = {
     const lastButton = buttons[buttons.length - 1];
     const lastGroup = groups[groups.length - 1];
 
-    await userEvent.click(lastButton);
-    await expect(args.onSelect).toHaveBeenCalledWith(lastGroup.id);
-
-    const indicator = canvasElement.querySelector(
-      '.border-b-g-500',
-    ) as HTMLElement;
-    const lastRect = lastButton.parentElement!.getBoundingClientRect();
-    const indicatorRect = indicator.getBoundingClientRect();
-
-    const lastCenterX = Math.round(lastRect.left + lastRect.width / 2);
-    const indicatorCenterX = Math.round(
-      indicatorRect.left + indicatorRect.width / 2,
+    // userEvent.click은 클릭 전에 요소를 자동으로 scrollIntoView 시켜
+    // 다이얼의 자체 스크롤 추적 로직과 충돌한다. 순수 클릭 이벤트만 보내는
+    // fireEvent를 사용해 리스트 밖으로 스크롤된 그룹을 실제로 클릭한 것처럼 재현한다.
+    fireEvent.click(lastButton);
+    await waitFor(() =>
+      expect(args.onSelect).toHaveBeenCalledWith(lastGroup.id),
     );
 
-    await expect(indicatorCenterX).toBe(lastCenterX);
+    await waitFor(() => {
+      const indicator = canvasElement.querySelector(
+        '.border-b-g-500',
+      ) as HTMLElement;
+      const lastRect = lastButton.parentElement!.getBoundingClientRect();
+      const indicatorRect = indicator.getBoundingClientRect();
+
+      const lastCenterX = Math.round(lastRect.left + lastRect.width / 2);
+      const indicatorCenterX = Math.round(
+        indicatorRect.left + indicatorRect.width / 2,
+      );
+
+      expect(indicatorCenterX).toBe(lastCenterX);
+    });
   },
 };
 
@@ -232,10 +237,11 @@ export const WithFriendRanking: Story = {
     scrollContainer.scrollLeft = 86;
     scrollContainer.dispatchEvent(new Event('scroll'));
     scrollContainer.dispatchEvent(new Event('scrollend'));
-    await new Promise((resolve) => setTimeout(resolve, 200));
 
     // 랭킹도 두 번째 그룹 멤버로 함께 바뀐다
-    await expect(canvas.getByText('어떤 모임 멤버1')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(canvas.getByText('어떤 모임 멤버1')).toBeInTheDocument(),
+    );
     await expect(
       canvas.queryByText('친구 많은 모임 멤버1'),
     ).not.toBeInTheDocument();

--- a/src/components/features/groups/GroupList/GroupList.stories.tsx
+++ b/src/components/features/groups/GroupList/GroupList.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { useState } from 'react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import RankingItem from '@/src/components/features/groups/Ranking/RankingItem/RankingItem';
 
 import GroupList from './GroupList';
 
@@ -74,4 +77,167 @@ export const LongName: Story = {
     );
   },
   args: { groups: longNameGroups },
+};
+
+// 리스트를 스크롤하면 바늘(세모) 아래로 지나가는 그룹이 자동으로 포커스된다
+export const DialScroll: Story = {
+  args: { groups, onSelect: fn() },
+  render: (args) => {
+    const [selectedId, setSelectedId] = useState(1);
+    return (
+      <div style={{ width: 393 }}>
+        <GroupList
+          groups={groups}
+          selectedId={selectedId}
+          onSelect={(id) => {
+            args.onSelect?.(id);
+            setSelectedId(id);
+          }}
+        />
+      </div>
+    );
+  },
+  play: async ({ args, canvasElement }) => {
+    const scrollContainer = canvasElement.querySelector(
+      '.overflow-x-auto',
+    ) as HTMLElement;
+
+    // 사용자가 리스트를 드래그/휠 스크롤한 상황을 재현한다
+    scrollContainer.scrollLeft = 180;
+    scrollContainer.dispatchEvent(new Event('scroll'));
+    scrollContainer.dispatchEvent(new Event('scrollend'));
+
+    // scrollend 미지원 환경의 debounce(120ms) 폴백까지 여유를 둔다
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    await expect(args.onSelect).toHaveBeenCalled();
+
+    const canvas = within(canvasElement);
+    const focusedButton = canvas.getAllByRole('button', { pressed: true })[0];
+    await expect(focusedButton).toBeVisible();
+  },
+};
+
+// 스크롤이 끝까지 닿지 않는 마지막 그룹을 클릭하면, 바늘이 실제로 멈춘
+// 그룹 위치로 이동한다 (바늘의 원래 고정 위치까지 못 오는 경계 케이스)
+export const DialEdgeClick: Story = {
+  args: { groups, onSelect: fn() },
+  render: (args) => {
+    const [selectedId, setSelectedId] = useState(1);
+    return (
+      <div style={{ width: 393 }}>
+        <GroupList
+          groups={groups}
+          selectedId={selectedId}
+          onSelect={(id) => {
+            args.onSelect?.(id);
+            setSelectedId(id);
+          }}
+        />
+      </div>
+    );
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const buttons = canvas.getAllByRole('button');
+    const lastButton = buttons[buttons.length - 1];
+    const lastGroup = groups[groups.length - 1];
+
+    await userEvent.click(lastButton);
+    await expect(args.onSelect).toHaveBeenCalledWith(lastGroup.id);
+
+    const indicator = canvasElement.querySelector(
+      '.border-b-g-500',
+    ) as HTMLElement;
+    const lastRect = lastButton.parentElement!.getBoundingClientRect();
+    const indicatorRect = indicator.getBoundingClientRect();
+
+    const lastCenterX = Math.round(lastRect.left + lastRect.width / 2);
+    const indicatorCenterX = Math.round(
+      indicatorRect.left + indicatorRect.width / 2,
+    );
+
+    await expect(indicatorCenterX).toBe(lastCenterX);
+  },
+};
+
+// GroupList 다이얼과 (실제 API를 타는 RankingSection 대신) 친구 랭킹 UI를
+// 나란히 붙여서, 그룹을 스크롤/클릭할 때 아래 랭킹도 함께 바뀌는지 리뷰어가
+// 직접 확인할 수 있게 한다.
+// RankingSection은 src/lib/api/instance.ts가 next/navigation의
+// unstable_rethrow를 가져오는데, Storybook의 Next.js 목이 이를 지원하지 않아
+// 스토리에서 임포트하면 깨진다. 그래서 API 의존이 없는 RankingItem을 목 데이터로
+// 직접 그려서 같은 UI/동선을 재현한다.
+const mockFriendsByGroupId: Record<
+  number,
+  { nickname: string; answerText: string; streakDays: number }[]
+> = Object.fromEntries(
+  groups.map((group) => [
+    group.id,
+    [
+      {
+        nickname: `${group.name} 멤버1`,
+        answerText: '친구들이랑 저녁 먹은 거요!',
+        streakDays: 12,
+      },
+      {
+        nickname: `${group.name} 멤버2`,
+        answerText: '오늘은 그냥 쉬었어요.',
+        streakDays: 3,
+      },
+    ],
+  ]),
+);
+
+export const WithFriendRanking: Story = {
+  args: { groups },
+  render: () => {
+    const [selectedGroupId, setSelectedGroupId] = useState(groups[0].id);
+    const friends = mockFriendsByGroupId[selectedGroupId] ?? [];
+
+    return (
+      <div style={{ width: 393 }}>
+        <GroupList
+          groups={groups}
+          selectedId={selectedGroupId}
+          onSelect={setSelectedGroupId}
+        />
+        <ul className="bg-g-500 space-y-8 px-5 py-6">
+          {friends.map((friend, index) => (
+            <RankingItem
+              key={friend.nickname}
+              isExistImg
+              nickname={friend.nickname}
+              answerText={friend.answerText}
+              streakDays={friend.streakDays}
+              ranking={index + 1}
+              userCategory="PRESENT_HEDONISTIC"
+              onClick={() => {}}
+            />
+          ))}
+        </ul>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 처음엔 첫 그룹의 멤버가 랭킹에 보인다
+    await expect(canvas.getByText('친구 많은 모임 멤버1')).toBeInTheDocument();
+
+    // 리스트를 두 번째 그룹 위치까지 스크롤하면
+    const scrollContainer = canvasElement.querySelector(
+      '.overflow-x-auto',
+    ) as HTMLElement;
+    scrollContainer.scrollLeft = 86;
+    scrollContainer.dispatchEvent(new Event('scroll'));
+    scrollContainer.dispatchEvent(new Event('scrollend'));
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // 랭킹도 두 번째 그룹 멤버로 함께 바뀐다
+    await expect(canvas.getByText('어떤 모임 멤버1')).toBeInTheDocument();
+    await expect(
+      canvas.queryByText('친구 많은 모임 멤버1'),
+    ).not.toBeInTheDocument();
+  },
 };

--- a/src/components/features/groups/GroupList/GroupList.tsx
+++ b/src/components/features/groups/GroupList/GroupList.tsx
@@ -3,6 +3,7 @@
 import AvatarButton from '@/src/components/ui/AvatarButton/AvatarButton';
 
 import type { GroupType } from '../constants/groupType';
+import { useGroupDialIndicator } from '../hooks/useGroupDialIndicator';
 
 interface GroupItem {
   id: number;
@@ -18,18 +19,37 @@ interface GroupListProps {
 }
 
 const GroupList = ({ groups, selectedId, onSelect }: GroupListProps) => {
+  const { scrollRef, indicatorRef, registerItemRef, handleSelect } =
+    useGroupDialIndicator({ groups, selectedId, onSelect });
+
   return (
-    <div className="flex h-28 items-start pt-4 gap-4 overflow-x-auto overflow-y-hidden scrollbar-hidden">
-      {groups.map((item, idx) => (
-        <AvatarButton
-          key={item.id}
-          src={item.image || '/images/default-group.svg'}
-          label={item.name}
-          isSelected={selectedId === item.id}
-          onClick={() => onSelect?.(item.id)}
-          preload={idx < 5}
-        />
-      ))}
+    <div className="relative">
+      <div
+        ref={scrollRef}
+        className="flex h-32 items-start pt-4 gap-4 overflow-x-auto overflow-y-hidden scrollbar-hidden snap-x snap-mandatory"
+      >
+        {groups.map((item, idx) => (
+          <div
+            key={item.id}
+            ref={registerItemRef(item.id)}
+            className="shrink-0 snap-start snap-always"
+          >
+            <AvatarButton
+              src={item.image || '/images/default-group.svg'}
+              label={item.name}
+              isSelected={selectedId === item.id}
+              onClick={() => handleSelect(item.id)}
+              preload={idx < 5}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div
+        ref={indicatorRef}
+        aria-hidden
+        className="invisible absolute -bottom-2 h-0 w-0 border-x-13 border-b-18 border-x-transparent border-b-g-500"
+      />
     </div>
   );
 };

--- a/src/components/features/groups/hooks/useGroupDialIndicator.ts
+++ b/src/components/features/groups/hooks/useGroupDialIndicator.ts
@@ -104,7 +104,10 @@ export const useGroupDialIndicator = <T extends GroupDialItem>({
     moveIndicatorTo(getScreenCenter(closest.el, container.scrollLeft));
   }, [findClosestToPointer, moveIndicatorTo, onSelect]);
 
-  useEffect(() => {
+  // 스크롤 리스너 등록을 useEffect(커밋 이후 비동기 스케줄)가 아닌
+  // useLayoutEffect(커밋 중 동기 실행)로 붙여야, 마운트 직후 곧바로 스크롤이
+  // 발생해도 리스너가 이미 붙어있어 놓치지 않는다.
+  useLayoutEffect(() => {
     const container = scrollRef.current;
     if (!container) return;
 

--- a/src/components/features/groups/hooks/useGroupDialIndicator.ts
+++ b/src/components/features/groups/hooks/useGroupDialIndicator.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+
+interface GroupDialItem {
+  id: number;
+}
+
+interface UseGroupDialIndicatorParams<T extends GroupDialItem> {
+  groups: T[];
+  selectedId?: number;
+  onSelect?: (id: number) => void;
+}
+
+const INDICATOR_HALF_WIDTH = 13;
+const SCROLL_SETTLE_MS = 120;
+
+const getScreenCenter = (el: HTMLDivElement, scrollLeft: number) =>
+  el.offsetLeft + el.offsetWidth / 2 - scrollLeft;
+
+/**
+ * 그룹 아바타 리스트를 다이얼처럼 스크롤할 때, 화면상 고정된 바늘(세모 인디케이터)
+ * 아래로 지나가는 그룹을 자동으로 포커스한다.
+ * - 리스트는 snap-mandatory로 한 그룹씩 딱딱 걸리며 스크롤된다.
+ * - 리스트 끝부분처럼 스크롤이 바늘 위치까지 닿지 못하면, 바늘을 실제로 멈춘
+ *   그룹 쪽으로 옮긴다.
+ */
+export const useGroupDialIndicator = <T extends GroupDialItem>({
+  groups,
+  selectedId,
+  onSelect,
+}: UseGroupDialIndicatorParams<T>) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const indicatorRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef(new Map<number, HTMLDivElement>());
+  const selectedIdRef = useRef(selectedId);
+  const pointerXRef = useRef<number | null>(null);
+  const suppressSettleRef = useRef(false);
+
+  useEffect(() => {
+    selectedIdRef.current = selectedId;
+  }, [selectedId]);
+
+  const moveIndicatorTo = useCallback((centerX: number) => {
+    if (!indicatorRef.current) return;
+    indicatorRef.current.style.left = `${centerX - INDICATOR_HALF_WIDTH}px`;
+  }, []);
+
+  const findClosestToPointer = useCallback((container: HTMLDivElement) => {
+    const pointerX = pointerXRef.current;
+    if (pointerX === null) return null;
+
+    let closestId: number | null = null;
+    let closestEl: HTMLDivElement | null = null;
+    let minDistance = Infinity;
+
+    for (const [id, el] of itemRefs.current) {
+      const distance = Math.abs(
+        getScreenCenter(el, container.scrollLeft) - pointerX,
+      );
+      if (distance < minDistance) {
+        minDistance = distance;
+        closestId = id;
+        closestEl = el;
+      }
+    }
+
+    return closestId !== null && closestEl !== null
+      ? { id: closestId, el: closestEl }
+      : null;
+  }, []);
+
+  // 첫 그룹의 중심을 바늘의 화면상 고정 위치로 삼는다.
+  useLayoutEffect(() => {
+    if (pointerXRef.current !== null) return;
+    const first = groups[0];
+    const target = first ? itemRefs.current.get(first.id) : undefined;
+    const container = scrollRef.current;
+    if (!target || !container) return;
+
+    const pointerX = target.offsetLeft + target.offsetWidth / 2;
+    pointerXRef.current = pointerX;
+    container.style.scrollPaddingLeft = `${pointerX - target.offsetWidth / 2}px`;
+
+    moveIndicatorTo(pointerX);
+    if (indicatorRef.current) indicatorRef.current.style.visibility = 'visible';
+  }, [groups, moveIndicatorTo]);
+
+  const settleFocus = useCallback(() => {
+    // 클릭으로 인한 스크롤은 handleSelect에서 이미 확정 처리했으므로
+    // 여기서 바늘 최근접 탐색으로 다시 덮어쓰지 않는다.
+    if (suppressSettleRef.current) {
+      suppressSettleRef.current = false;
+      return;
+    }
+
+    const container = scrollRef.current;
+    if (!container) return;
+
+    const closest = findClosestToPointer(container);
+    if (!closest) return;
+
+    if (closest.id !== selectedIdRef.current) {
+      onSelect?.(closest.id);
+    }
+    moveIndicatorTo(getScreenCenter(closest.el, container.scrollLeft));
+  }, [findClosestToPointer, moveIndicatorTo, onSelect]);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    // scrollend를 지원하면 스냅이 실제로 멈춘 시점에 정확히 포커스를 갱신하고,
+    // 미지원 브라우저는 debounce로 대체한다.
+    if ('onscrollend' in window) {
+      container.addEventListener('scrollend', settleFocus);
+      return () => container.removeEventListener('scrollend', settleFocus);
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const handleScroll = () => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(settleFocus, SCROLL_SETTLE_MS);
+    };
+
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      container.removeEventListener('scroll', handleScroll);
+      clearTimeout(timeoutId);
+    };
+  }, [settleFocus]);
+
+  const registerItemRef = useCallback(
+    (id: number) => (el: HTMLDivElement | null) => {
+      if (el) itemRefs.current.set(id, el);
+      else itemRefs.current.delete(id);
+    },
+    [],
+  );
+
+  const handleSelect = useCallback(
+    (id: number) => {
+      onSelect?.(id);
+
+      const container = scrollRef.current;
+      const target = itemRefs.current.get(id);
+      const pointerX = pointerXRef.current;
+      if (!container || !target || pointerX === null) return;
+
+      // 리스트 끝부분처럼 바늘 위치까지 스크롤이 닿지 못하면 실제 도달 가능한
+      // 위치로 미리 clamp해서, 세모도 그 실제 위치로 바로 옮겨준다.
+      const desiredLeft = target.offsetLeft + target.offsetWidth / 2 - pointerX;
+      const maxScrollLeft = container.scrollWidth - container.clientWidth;
+      const clampedLeft = Math.min(Math.max(desiredLeft, 0), maxScrollLeft);
+
+      if (clampedLeft !== container.scrollLeft) {
+        suppressSettleRef.current = true;
+        container.scrollTo({ left: clampedLeft, behavior: 'smooth' });
+      }
+
+      moveIndicatorTo(getScreenCenter(target, clampedLeft));
+    },
+    [moveIndicatorTo, onSelect],
+  );
+
+  return { scrollRef, indicatorRef, registerItemRef, handleSelect };
+};


### PR DESCRIPTION
## What is this PR? :mag:

그룹 회고 화면에서 그룹 리스트와 친구 랭킹의 연결이 시각적으로 끊어져 있던 문제.

- Figma 디자인상 그룹 리스트 아래 세모(▲) 인디케이터 존재
- 이를 실제 다이얼 피커처럼 동작하도록 구현: 화면 고정 위치에 바늘 배치, 리스트 스크롤 시 바늘 아래로 지나가는 그룹 자동 포커스, 하단 친구 랭킹도 함께 갱신

## Changes :memo:

- **다이얼 동작**: 첫 그룹 초기 위치를 바늘의 화면 고정 좌표로 설정. `scroll-snap-type: mandatory`로 그룹 단위 스크롤 락 적용. 스크롤 정지 시(`scrollend`, 미지원 브라우저는 debounce 폴백) 바늘 최근접 그룹 자동 포커스
- **경계 케이스 보정**: 리스트 끝부분(스크롤이 바늘 위치까지 도달 불가한 그룹) 클릭 시, 실제 스크롤 가능 범위로 사전 clamp 후 바늘도 해당 위치로 즉시 이동. 클릭발 스크롤 이벤트와 자동 포커스 로직 간 충돌(선택 덮어쓰기) 방지 처리 포함
- **레이아웃**: 그룹명 2줄 줄바꿈 시 라벨-바늘 겹침 현상 → 리스트 행 높이 확장으로 해결 (하단 친구 랭킹 시작 위치도 자연스럽게 동반 하강)
- **구조 분리**: 스크롤/DOM 위치 계산 로직을 `useGroupDialIndicator` 커스텀 훅으로 추출, `GroupList`는 마크업 전용으로 정리

### 구조 요약
```text
src/components/features/groups/
  GroupList/GroupList.tsx           마크업 + 훅 호출
  hooks/useGroupDialIndicator.ts    다이얼 바늘 위치·스냅 포커스·경계 clamp 로직
  GroupList/GroupList.stories.tsx   리뷰용 인터랙션 스토리
```

### 리뷰 포인트
Storybook에서 아래 스토리로 직접 확인 가능:
- [Dial Scroll](https://6a0747043a4480833f4697f4-rxugiwqqnk.chromatic.com/?path=/story/features-groups-grouplist--dial-scroll): 스크롤하면 바늘 아래 그룹이 자동 포커스되는지
- [Dial Edge Click](https://6a0747043a4480833f4697f4-rxugiwqqnk.chromatic.com/?path=/story/features-groups-grouplist--dial-edge-click): 리스트 끝 그룹 클릭 시 바늘이 실제 위치로 정확히 이동하는지
- [With Friend Ranking](https://6a0747043a4480833f4697f4-rxugiwqqnk.chromatic.com/?path=/story/features-groups-grouplist--with-friend-ranking): 그룹을 스크롤/클릭할 때 아래 친구 랭킹 목록도 함께 바뀌는지 (실제 `RankingSection`은 API 훅 의존 때문에 Storybook에서 못 띄워서, 같은 UI를 목 데이터로 재현)

## Related Issues :link:

close #204

## Screenshot :camera:

해당 없음 (Storybook 인터랙션 스토리로 대체 확인)

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?