### PR TITLE
[Feat] 회고 피드백 화면 지수 변화 반영

### DIFF
--- a/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
+++ b/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
@@ -9,6 +9,7 @@ import ErrorState from '@/src/components/ui/ErrorState/ErrorState';
 import { goToHome } from '@/src/lib/helpers/navigation';
 
 import { useTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
+import { useUserDetailQuery } from '../../users/queries/useUserDetailQuery';
 import CompleteButton from '../CompleteButton/CompleteButton';
 import GeneratingFeedbackCard from '../GeneratingFeedbackCard/GeneratingFeedbackCard';
 import { useReflectionFeedbackDetailQuery } from '../queries/useReflectionFeedbackDetailQuery';
@@ -50,6 +51,8 @@ const FeedbackSection = () => {
 
   const { data: feedbackDetail, isError: isDetailError } =
     useReflectionFeedbackDetailQuery(id, hasCompletedFeedback);
+  const { data: userDetail } = useUserDetailQuery();
+  const streakDays = userDetail?.streakDays ?? 0;
   const isDetailLoading =
     hasCompletedFeedback && !feedbackDetail && !isDetailError;
   const isFeedbackLoading = isGenerating || isDetailLoading;
@@ -115,6 +118,7 @@ const FeedbackSection = () => {
         category={category}
         changedScore={feedbackDetail.changedScore}
         isIncreased={feedbackDetail.isIncreased}
+        streakDays={streakDays}
       />
       <BottomCTA>
         <div className="flex w-full flex-col gap-2.5">

--- a/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
+++ b/src/components/features/reflectionFeedback/FeedbackSection/FeedbackSection.tsx
@@ -11,6 +11,7 @@ import { goToHome } from '@/src/lib/helpers/navigation';
 import { useTodayReflectionQuery } from '../../reflection/queries/useTodayReflectionQuery';
 import CompleteButton from '../CompleteButton/CompleteButton';
 import GeneratingFeedbackCard from '../GeneratingFeedbackCard/GeneratingFeedbackCard';
+import { useReflectionFeedbackDetailQuery } from '../queries/useReflectionFeedbackDetailQuery';
 import ResultCard from '../ResultCard/ResultCard';
 
 const FEEDBACK_TIMEOUT_MS = 10000;
@@ -34,6 +35,7 @@ const FeedbackSection = () => {
     },
   });
 
+  const id = data?.id;
   const feedback = data?.feedback;
   const category = data?.question?.category;
   const feedbackContent = feedback?.content;
@@ -45,15 +47,22 @@ const FeedbackSection = () => {
         feedback.status === 'PROCESSING'));
   const hasCompletedFeedback =
     feedback?.status === 'COMPLETED' && Boolean(feedbackContent);
+
+  const { data: feedbackDetail, isError: isDetailError } =
+    useReflectionFeedbackDetailQuery(id, hasCompletedFeedback);
+  const isDetailLoading =
+    hasCompletedFeedback && !feedbackDetail && !isDetailError;
+  const isFeedbackLoading = isGenerating || isDetailLoading;
   const hasError =
     isError ||
     isTimedOut ||
+    isDetailError ||
     feedback?.status === 'FAILED' ||
     !hasCompletedFeedback ||
     !category;
 
   useEffect(() => {
-    if (!isGenerating || isTimedOut) {
+    if (!isFeedbackLoading || isTimedOut) {
       return;
     }
 
@@ -64,9 +73,9 @@ const FeedbackSection = () => {
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [isGenerating, isTimedOut]);
+  }, [isFeedbackLoading, isTimedOut]);
 
-  if (isGenerating) {
+  if (isFeedbackLoading) {
     return (
       <>
         <GeneratingFeedbackCard />
@@ -88,7 +97,7 @@ const FeedbackSection = () => {
     );
   }
 
-  if (!feedbackContent || !category) {
+  if (!feedbackContent || !category || !feedbackDetail) {
     return (
       <ErrorState
         title="피드백을 불러오지 못했어요"
@@ -101,9 +110,21 @@ const FeedbackSection = () => {
 
   return (
     <section>
-      <ResultCard feedback={feedbackContent} category={category} />
+      <ResultCard
+        feedback={feedbackContent}
+        category={category}
+        changedScore={feedbackDetail.changedScore}
+        isIncreased={feedbackDetail.isIncreased}
+      />
       <BottomCTA>
-        <CompleteButton />
+        <div className="flex w-full flex-col gap-2.5">
+          <CompleteButton />
+          <Button
+            label="변화보기"
+            variant="secondary"
+            onClick={() => router.push('/statistics')}
+          />
+        </div>
       </BottomCTA>
     </section>
   );

--- a/src/components/features/reflectionFeedback/ResultCard/ResultCard.stories.tsx
+++ b/src/components/features/reflectionFeedback/ResultCard/ResultCard.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import ResultCard from './ResultCard';
+
+const SAMPLE_FEEDBACK =
+  '어려움 속에서도 도전을 이어가셨던 경험이 있으셨군요. 그 과정에서 조금씩 어려움을 극복해나가셨다는 점이 인상 깊어요. 앞으로도 긍정적인 마음으로 나아가시길 응원해요.';
+
+const meta = {
+  title: 'Features/ReflectionFeedback/ResultCard',
+  component: ResultCard,
+  parameters: {
+    layout: 'centered',
+    viewport: { defaultViewport: 'mobile1' },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="w-90">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    feedback: SAMPLE_FEEDBACK,
+    category: 'PAST_NEGATIVE',
+    changedScore: 0.1666666,
+    isIncreased: true,
+    streakDays: 3,
+  },
+} satisfies Meta<typeof ResultCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FirstReflection: Story = {
+  args: {
+    streakDays: 1,
+  },
+};
+
+export const Streak: Story = {
+  args: {
+    streakDays: 7,
+  },
+};
+
+export const PastPositive: Story = {
+  args: {
+    category: 'PAST_POSITIVE',
+  },
+};
+
+export const Future: Story = {
+  args: {
+    category: 'FUTURE',
+  },
+};
+
+export const Decreased: Story = {
+  args: {
+    isIncreased: false,
+  },
+};
+
+export const LongFeedback: Story = {
+  args: {
+    feedback: SAMPLE_FEEDBACK.repeat(4),
+  },
+};

--- a/src/components/features/reflectionFeedback/ResultCard/ResultCard.tsx
+++ b/src/components/features/reflectionFeedback/ResultCard/ResultCard.tsx
@@ -10,27 +10,36 @@ import {
 import { cn } from '@/src/lib/helpers/cn';
 
 import { useUserDetailQuery } from '../../users/queries/useUserDetailQuery';
-import { getCategoryMessage } from '../utils/getCategoryMessage';
+import { getScoreMessage } from '../utils/getScoreMessage';
 
 interface ResultCardProps {
   feedback: string;
   category: Category;
+  changedScore: number;
+  isIncreased: boolean;
 }
 
-const ResultCard = ({ feedback, category }: ResultCardProps) => {
+const ResultCard = ({
+  feedback,
+  category,
+  changedScore,
+  isIncreased,
+}: ResultCardProps) => {
   const { data } = useUserDetailQuery();
 
   const streakDays = data?.streakDays ?? 0;
-  const categoryMessage = getCategoryMessage(category);
+  const badgeLabel =
+    streakDays <= 1 ? '첫 회고 달성!' : `${streakDays}일 연속 회고 중!`;
+  const scoreMessage = getScoreMessage({ category, changedScore, isIncreased });
   const characterAsset = CATEGORY_CHARACTER_MAP[category];
 
   // 200px = PageHeader(56) + page pt-10(40) + page pb-24(96) + buffer(8)
   return (
-    <Card className="flex flex-col items-center gap-6 py-10 px-8 bg-g-500 min-h-115 max-h-[calc(100dvh-200px)]">
+    <Card className="flex flex-col items-center gap-6 py-10 px-8  min-h-115 max-h-[calc(100dvh-200px)]">
       <Badge variant="neutral">
         <div className="flex items-center gap-1">
           <Icon name="check" size={16} />
-          <p>{streakDays}일 연속 회고 중!</p>
+          <p>{badgeLabel}</p>
         </div>
       </Badge>
 
@@ -41,12 +50,11 @@ const ResultCard = ({ feedback, category }: ResultCardProps) => {
         height={150}
       />
 
-      <p className="font-heading-h3 text-g-0">
-        {categoryMessage.prefix}
-        <span className={characterAsset.color}>
-          {categoryMessage.highlight}
-        </span>
-        {categoryMessage.suffix}
+      <p className="text-center font-heading-h3 text-g-0">
+        <span className={characterAsset.color}>{scoreMessage.category}</span>
+        {scoreMessage.particle}
+        <span className={characterAsset.color}>{scoreMessage.highlight}</span>
+        {scoreMessage.suffix}
       </p>
 
       <div

--- a/src/components/features/reflectionFeedback/ResultCard/ResultCard.tsx
+++ b/src/components/features/reflectionFeedback/ResultCard/ResultCard.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/src/lib/constants/character';
 import { cn } from '@/src/lib/helpers/cn';
 
-import { useUserDetailQuery } from '../../users/queries/useUserDetailQuery';
 import { getScoreMessage } from '../utils/getScoreMessage';
 
 interface ResultCardProps {
@@ -17,6 +16,7 @@ interface ResultCardProps {
   category: Category;
   changedScore: number;
   isIncreased: boolean;
+  streakDays: number;
 }
 
 const ResultCard = ({
@@ -24,10 +24,8 @@ const ResultCard = ({
   category,
   changedScore,
   isIncreased,
+  streakDays,
 }: ResultCardProps) => {
-  const { data } = useUserDetailQuery();
-
-  const streakDays = data?.streakDays ?? 0;
   const badgeLabel =
     streakDays <= 1 ? '첫 회고 달성!' : `${streakDays}일 연속 회고 중!`;
   const scoreMessage = getScoreMessage({ category, changedScore, isIncreased });

--- a/src/components/features/reflectionFeedback/constants/categoryLabels.ts
+++ b/src/components/features/reflectionFeedback/constants/categoryLabels.ts
@@ -1,0 +1,9 @@
+import type { Category } from '@/src/lib/constants/character';
+
+export const CATEGORY_LABEL_MAP: Record<Category, string> = {
+  PAST_POSITIVE: '과거 긍정',
+  PAST_NEGATIVE: '과거 부정',
+  PRESENT_HEDONISTIC: '현재 쾌락',
+  PRESENT_FATALISTIC: '현재 운명',
+  FUTURE: '미래 지향',
+};

--- a/src/components/features/reflectionFeedback/constants/queryKeys.ts
+++ b/src/components/features/reflectionFeedback/constants/queryKeys.ts
@@ -1,4 +1,6 @@
 export const reflectionFeedbackKeys = {
   all: ['reflectionFeedback'] as const,
   create: () => [...reflectionFeedbackKeys.all, 'create'] as const,
+  detail: (id: number) =>
+    [...reflectionFeedbackKeys.all, 'detail', id] as const,
 };

--- a/src/components/features/reflectionFeedback/constants/url.ts
+++ b/src/components/features/reflectionFeedback/constants/url.ts
@@ -1,3 +1,4 @@
 export const REFLECTION_FEEDBACK_ENDPOINTS = {
   createFeedback: (id: number) => `/reflections/${id}/feedback`,
+  feedbackDetail: (id: number) => `/reflections/${id}/feedback`,
 } as const;

--- a/src/components/features/reflectionFeedback/queries/useReflectionFeedbackDetailQuery.ts
+++ b/src/components/features/reflectionFeedback/queries/useReflectionFeedbackDetailQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { skipToken, useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { get } from '@/src/lib/api';
@@ -19,7 +19,7 @@ const feedbackDetailSchema = z.object({
   beforeScore: z.number().nullish(),
   afterScore: z.number().nullish(),
   failureReason: z.string().nullish(),
-  createdAt: z.string(),
+  createdAt: z.coerce.date(),
 });
 
 export type ReflectionFeedbackDetailType = z.infer<typeof feedbackDetailSchema>;
@@ -38,6 +38,8 @@ export const useReflectionFeedbackDetailQuery = (
 ) =>
   useQuery({
     queryKey: reflectionFeedbackKeys.detail(reflectionId ?? 0),
-    queryFn: () => getReflectionFeedbackDetail(reflectionId as number),
-    enabled: enabled && reflectionId !== undefined,
+    queryFn:
+      enabled && reflectionId !== undefined
+        ? () => getReflectionFeedbackDetail(reflectionId)
+        : skipToken,
   });

--- a/src/components/features/reflectionFeedback/queries/useReflectionFeedbackDetailQuery.ts
+++ b/src/components/features/reflectionFeedback/queries/useReflectionFeedbackDetailQuery.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { get } from '@/src/lib/api';
+import { CATEGORY } from '@/src/lib/constants/character';
+
+import { reflectionFeedbackKeys } from '../constants/queryKeys';
+import { REFLECTION_FEEDBACK_ENDPOINTS } from '../constants/url';
+
+const feedbackDetailSchema = z.object({
+  id: z.number(),
+  reflectionId: z.number(),
+  category: z.enum(CATEGORY),
+  score: z.number(),
+  content: z.string().nullable(),
+  status: z.enum(['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED']),
+  changedScore: z.number(),
+  isIncreased: z.boolean(),
+  beforeScore: z.number().nullish(),
+  afterScore: z.number().nullish(),
+  failureReason: z.string().nullish(),
+  createdAt: z.string(),
+});
+
+export type ReflectionFeedbackDetailType = z.infer<typeof feedbackDetailSchema>;
+
+const getReflectionFeedbackDetail = (reflectionId: number) =>
+  get<ReflectionFeedbackDetailType>(
+    REFLECTION_FEEDBACK_ENDPOINTS.feedbackDetail(reflectionId),
+    {
+      responseSchema: feedbackDetailSchema,
+    },
+  );
+
+export const useReflectionFeedbackDetailQuery = (
+  reflectionId: number | undefined,
+  enabled: boolean,
+) =>
+  useQuery({
+    queryKey: reflectionFeedbackKeys.detail(reflectionId ?? 0),
+    queryFn: () => getReflectionFeedbackDetail(reflectionId as number),
+    enabled: enabled && reflectionId !== undefined,
+  });

--- a/src/components/features/reflectionFeedback/utils/getScoreMessage.ts
+++ b/src/components/features/reflectionFeedback/utils/getScoreMessage.ts
@@ -1,0 +1,37 @@
+import type { Category } from '@/src/lib/constants/character';
+
+import { CATEGORY_LABEL_MAP } from '../constants/categoryLabels';
+
+export interface ScoreMessageParts {
+  /** 카테고리 색 강조: "과거 부정 지수" */
+  category: string;
+  /** 흰색 조사: "가 " */
+  particle: string;
+  /** 카테고리 색 강조: "0.2%" */
+  highlight: string;
+  /** 흰색: " 올랐어요." */
+  suffix: string;
+}
+
+interface ScoreMessageParams {
+  category: Category;
+  changedScore: number;
+  isIncreased: boolean;
+}
+
+export const getScoreMessage = ({
+  category,
+  changedScore,
+  isIncreased,
+}: ScoreMessageParams): ScoreMessageParts => {
+  const label = CATEGORY_LABEL_MAP[category];
+  const verb = isIncreased ? '올랐어요' : '내렸어요';
+  const rate = Math.abs(changedScore).toFixed(1);
+
+  return {
+    category: `${label} 지수`,
+    particle: '가 ',
+    highlight: `${rate}%`,
+    suffix: ` ${verb}.`,
+  };
+};


### PR DESCRIPTION
## What is this PR? :mag:

회고를 작성하면 뜨는 **피드백 화면**을 디자인에 맞춰 "지수 변화"를 보여주도록 개편했다.

기존엔 카테고리 소개 문구 + AI 피드백 텍스트만 있었는데, 이제 회고 후 해당 시간관 지수가 얼마나 변했는지(예: `과거 부정 지수가 0.2% 올랐어요`)를 캐릭터·배지와 함께 보여주고, 통계 화면으로 넘어가는 **변화보기** 동선을 추가했다.

추가로, 피드백 화면이 **무한 폴링에 빠지던 버그**를 잡았다 — 지수 필드가 `/reflections/today` 응답엔 없는데 스키마가 필수로 요구해 파싱이 깨지면서, 완료(COMPLETED)됐는데도 요청이 멈추지 않고 화면 이동도 막히던 문제.

## Changes :memo:

- **지수 변화 조회 API 추가**: 지수 필드(`changedScore`·`isIncreased`·`category`)는 `/reflections/today`엔 없고 `GET /reflections/{id}/feedback`에만 있어서 상세 조회 훅을 새로 만들었다. 피드백이 완료됐을 때만 `skipToken`으로 조건부 조회 → 불필요한 요청과 `as` 캐스팅을 함께 제거
- **지수 문구 로직**: 카테고리 라벨 맵 + `getScoreMessage`로 `{라벨} 지수가 {N}% {올랐/내렸}어요`를 조립. `changedScore`(예 0.1666…)는 소수 1자리 반올림, 방향은 `isIncreased`로 분기해 하락 케이스까지 방어
- **결과 카드 UI**: 첫 회고면 `첫 회고 달성!` 배지, 지수 문구는 카테고리색/흰색 강조를 분리. 데이터 의존(`useUserDetailQuery`)을 부모로 올려 `ResultCard`를 순수 컴포넌트로 만들고 스토리를 추가
- **버그 수정**: `today` 스키마에서 잘못 넣었던 지수 필드를 제거해 무한 폴링 해소
- **변화보기 버튼**: 통계 화면(`/statistics`)으로 이동

구조 요약:

```text
src/components/features/reflectionFeedback/
  ├─ queries/useReflectionFeedbackDetailQuery   지수 상세 조회(skipToken)
  ├─ constants/ (url·queryKeys·categoryLabels)  엔드포인트·쿼리키·라벨
  ├─ utils/getScoreMessage                      지수 문구 조립
  ├─ ResultCard/                                결과 카드 UI + 스토리
  └─ FeedbackSection/                           폴링·상태 오케스트레이션
```

## Related Issues :link:

없음

## Screenshot :camera:

(동작 화면 첨부 예정)

---

### Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reflection feedback now displays personalized score changes, category labels, and streak information.
  * Added a “변화보기” button to navigate to statistics.
  * Feedback results now handle loading and error states more clearly.
  * Added detailed result examples covering streaks, score decreases, categories, and long feedback.

* **Bug Fixes**
  * Improved feedback generation and detail-loading behavior for more reliable result rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->